### PR TITLE
Improve Grafana dashboard: full country names and resizable region panels

### DIFF
--- a/configs/monitoring/grafana/provisioning/dashboards/conduit.json
+++ b/configs/monitoring/grafana/provisioning/dashboards/conduit.json
@@ -1,5 +1,7 @@
 {
-  "annotations": { "list": [] },
+  "annotations": {
+    "list": []
+  },
   "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -8,427 +10,2145 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "green", "value": null },
-            { "color": "yellow", "value": 50 },
-            { "color": "orange", "value": 100 }
-          ]}
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "orange",
+                "value": 100
+              }
+            ]
+          }
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 3, "x": 0, "y": 0 },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto"
       },
       "pluginVersion": "10.4.1",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(conduit_connected_clients)", "refId": "A" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(conduit_connected_clients)",
+          "refId": "A"
+        }
       ],
       "title": "Connected",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "blue", "value": null }
-          ]}
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 3, "x": 3, "y": 0 },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 3,
+        "y": 0
+      },
       "id": 2,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto"
       },
       "pluginVersion": "10.4.1",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(conduit_connecting_clients)", "refId": "A" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(conduit_connecting_clients)",
+          "refId": "A"
+        }
       ],
       "title": "Connecting",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "orange", "value": null }
-          ]}
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "orange",
+                "value": null
+              }
+            ]
+          }
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 3, "x": 6, "y": 0 },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 6,
+        "y": 0
+      },
       "id": 10,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto"
       },
       "pluginVersion": "10.4.1",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(max_over_time(conduit_connected_clients[$__range])) + sum(max_over_time(conduit_connecting_clients[$__range]))", "refId": "A" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(max_over_time(conduit_connected_clients[$__range])) + sum(max_over_time(conduit_connecting_clients[$__range]))",
+          "refId": "A"
+        }
       ],
       "title": "Peak Clients",
       "description": "Maximum concurrent clients (connected + connecting) in the selected time range",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "bytes"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 3, "x": 9, "y": 0 },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 9,
+        "y": 0
+      },
       "id": 3,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto"
       },
       "pluginVersion": "10.4.1",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(conduit_bytes_downloaded)", "refId": "A" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(conduit_bytes_downloaded)",
+          "refId": "A"
+        }
       ],
       "title": "Total Download",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
           "unit": "bytes"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 3, "x": 12, "y": 0 },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 12,
+        "y": 0
+      },
       "id": 4,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto"
       },
       "pluginVersion": "10.4.1",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(conduit_bytes_uploaded)", "refId": "A" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(conduit_bytes_uploaded)",
+          "refId": "A"
+        }
       ],
       "title": "Total Upload",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
-            { "options": { "0": { "color": "red", "text": "Offline" }, "1": { "color": "green", "text": "Live" } }, "type": "value" }
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "text": "Offline"
+                },
+                "1": {
+                  "color": "green",
+                  "text": "Live"
+                }
+              },
+              "type": "value"
+            }
           ],
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "red", "value": null },
-            { "color": "green", "value": 1 }
-          ]}
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 3, "x": 15, "y": 0 },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 15,
+        "y": 0
+      },
       "id": 5,
       "options": {
         "colorMode": "background",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto"
       },
       "pluginVersion": "10.4.1",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "conduit_is_live", "refId": "A" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "conduit_is_live",
+          "refId": "A"
+        }
       ],
       "title": "Status",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "binBps"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 3, "x": 18, "y": 0 },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 18,
+        "y": 0
+      },
       "id": 6,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto"
       },
       "pluginVersion": "10.4.1",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(rate(conduit_bytes_downloaded[5m])) + sum(rate(conduit_bytes_uploaded[5m]))", "refId": "A" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(conduit_bytes_downloaded[5m])) + sum(rate(conduit_bytes_uploaded[5m]))",
+          "refId": "A"
+        }
       ],
       "title": "Current Rate",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "purple", "value": null }
-          ]}
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          }
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 3, "x": 21, "y": 0 },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 21,
+        "y": 0
+      },
       "id": 11,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto"
       },
       "pluginVersion": "10.4.1",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "conduit_max_common_clients", "refId": "A" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "conduit_max_common_clients",
+          "refId": "A"
+        }
       ],
       "title": "Max Clients",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
-            "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto",
-            "barAlignment": 0, "drawStyle": "line", "fillOpacity": 20, "gradientMode": "opacity",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
-            "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5,
-            "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": true,
-            "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" }
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
       "id": 7,
       "options": {
-        "legend": { "calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "pluginVersion": "10.4.1",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(conduit_connected_clients)", "legendFormat": "Connected", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(conduit_connecting_clients)", "legendFormat": "Connecting", "refId": "B" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(conduit_connected_clients)",
+          "legendFormat": "Connected",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(conduit_connecting_clients)",
+          "legendFormat": "Connecting",
+          "refId": "B"
+        }
       ],
       "title": "Client Connections",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
-            "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto",
-            "barAlignment": 0, "drawStyle": "line", "fillOpacity": 20, "gradientMode": "opacity",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
-            "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5,
-            "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": true,
-            "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" }
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "binBps"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
       "id": 8,
       "options": {
-        "legend": { "calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "pluginVersion": "10.4.1",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(rate(conduit_bytes_downloaded[5m]))", "legendFormat": "Download", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(rate(conduit_bytes_uploaded[5m]))", "legendFormat": "Upload", "refId": "B" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(conduit_bytes_downloaded[5m]))",
+          "legendFormat": "Download",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(conduit_bytes_uploaded[5m]))",
+          "legendFormat": "Upload",
+          "refId": "B"
+        }
       ],
       "title": "Bandwidth Rate",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
-            "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto",
-            "barAlignment": 0, "drawStyle": "line", "fillOpacity": 30, "gradientMode": "opacity",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
-            "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5,
-            "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": true,
-            "stacking": { "group": "A", "mode": "normal" }, "thresholdsStyle": { "mode": "off" }
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "bytes"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 12 },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
       "id": 9,
       "options": {
-        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "pluginVersion": "10.4.1",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(conduit_bytes_downloaded)", "legendFormat": "Download", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(conduit_bytes_uploaded)", "legendFormat": "Upload", "refId": "B" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(conduit_bytes_downloaded)",
+          "legendFormat": "Download",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(conduit_bytes_uploaded)",
+          "legendFormat": "Upload",
+          "refId": "B"
+        }
       ],
       "title": "Total Bandwidth Over Time",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": {
-            "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto",
-            "barAlignment": 0, "drawStyle": "line", "fillOpacity": 20, "gradientMode": "opacity",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
-            "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5,
-            "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": true,
-            "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" }
+          "color": {
+            "mode": "palette-classic"
           },
-          "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "AE": {
+                  "text": "AE: United Arab Emirates",
+                  "index": 0
+                },
+                "AF": {
+                  "text": "AF: Afghanistan",
+                  "index": 1
+                },
+                "AR": {
+                  "text": "AR: Argentina",
+                  "index": 2
+                },
+                "AU": {
+                  "text": "AU: Australia",
+                  "index": 3
+                },
+                "BF": {
+                  "text": "BF: Burkina Faso",
+                  "index": 4
+                },
+                "BH": {
+                  "text": "BH: Bahrain",
+                  "index": 5
+                },
+                "BR": {
+                  "text": "BR: Brazil",
+                  "index": 6
+                },
+                "BY": {
+                  "text": "BY: Belarus",
+                  "index": 7
+                },
+                "CN": {
+                  "text": "CN: China",
+                  "index": 8
+                },
+                "CO": {
+                  "text": "CO: Colombia",
+                  "index": 9
+                },
+                "CU": {
+                  "text": "CU: Cuba",
+                  "index": 10
+                },
+                "DJ": {
+                  "text": "DJ: Djibouti",
+                  "index": 11
+                },
+                "DO": {
+                  "text": "DO: Dominican Republic",
+                  "index": 12
+                },
+                "EC": {
+                  "text": "EC: Ecuador",
+                  "index": 13
+                },
+                "EG": {
+                  "text": "EG: Egypt",
+                  "index": 14
+                },
+                "ET": {
+                  "text": "ET: Ethiopia",
+                  "index": 15
+                },
+                "GA": {
+                  "text": "GA: Gabon",
+                  "index": 16
+                },
+                "GN": {
+                  "text": "GN: Guinea",
+                  "index": 17
+                },
+                "GQ": {
+                  "text": "GQ: Equatorial Guinea",
+                  "index": 18
+                },
+                "GY": {
+                  "text": "GY: Guyana",
+                  "index": 19
+                },
+                "HK": {
+                  "text": "HK: Hong Kong",
+                  "index": 20
+                },
+                "ID": {
+                  "text": "ID: Indonesia",
+                  "index": 21
+                },
+                "IN": {
+                  "text": "IN: India",
+                  "index": 22
+                },
+                "IQ": {
+                  "text": "IQ: Iraq",
+                  "index": 23
+                },
+                "IR": {
+                  "text": "IR: Iran",
+                  "index": 24
+                },
+                "JO": {
+                  "text": "JO: Jordan",
+                  "index": 25
+                },
+                "KG": {
+                  "text": "KG: Kyrgyzstan",
+                  "index": 26
+                },
+                "LB": {
+                  "text": "LB: Lebanon",
+                  "index": 27
+                },
+                "LY": {
+                  "text": "LY: Libya",
+                  "index": 28
+                },
+                "MM": {
+                  "text": "MM: Myanmar",
+                  "index": 29
+                },
+                "MX": {
+                  "text": "MX: Mexico",
+                  "index": 30
+                },
+                "MY": {
+                  "text": "MY: Malaysia",
+                  "index": 31
+                },
+                "MZ": {
+                  "text": "MZ: Mozambique",
+                  "index": 32
+                },
+                "NG": {
+                  "text": "NG: Nigeria",
+                  "index": 33
+                },
+                "OM": {
+                  "text": "OM: Oman",
+                  "index": 34
+                },
+                "PA": {
+                  "text": "PA: Panama",
+                  "index": 35
+                },
+                "PH": {
+                  "text": "PH: Philippines",
+                  "index": 36
+                },
+                "PK": {
+                  "text": "PK: Pakistan",
+                  "index": 37
+                },
+                "QA": {
+                  "text": "QA: Qatar",
+                  "index": 38
+                },
+                "RU": {
+                  "text": "RU: Russia",
+                  "index": 39
+                },
+                "SA": {
+                  "text": "SA: Saudi Arabia",
+                  "index": 40
+                },
+                "SD": {
+                  "text": "SD: Sudan",
+                  "index": 41
+                },
+                "SN": {
+                  "text": "SN: Senegal",
+                  "index": 42
+                },
+                "SY": {
+                  "text": "SY: Syria",
+                  "index": 43
+                },
+                "TH": {
+                  "text": "TH: Thailand",
+                  "index": 44
+                },
+                "TR": {
+                  "text": "TR: Turkey",
+                  "index": 45
+                },
+                "TW": {
+                  "text": "TW: Taiwan",
+                  "index": 46
+                },
+                "TZ": {
+                  "text": "TZ: Tanzania",
+                  "index": 47
+                },
+                "UA": {
+                  "text": "UA: Ukraine",
+                  "index": 48
+                },
+                "UG": {
+                  "text": "UG: Uganda",
+                  "index": 49
+                },
+                "US": {
+                  "text": "US: United States",
+                  "index": 50
+                },
+                "VE": {
+                  "text": "VE: Venezuela",
+                  "index": 51
+                },
+                "YE": {
+                  "text": "YE: Yemen",
+                  "index": 52
+                },
+                "ZA": {
+                  "text": "ZA: South Africa",
+                  "index": 53
+                },
+                "ZW": {
+                  "text": "ZW: Zimbabwe",
+                  "index": 54
+                }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AE: United Arab Emirates"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AF"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AF: Afghanistan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AR: Argentina"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AU"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AU: Australia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BF"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BF: Burkina Faso"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BH"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BH: Bahrain"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BR: Brazil"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BY"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BY: Belarus"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CN"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CN: China"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CO"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CO: Colombia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CU"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CU: Cuba"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "DJ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "DJ: Djibouti"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "DO"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "DO: Dominican Republic"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "EC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "EC: Ecuador"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "EG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "EG: Egypt"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ET"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "ET: Ethiopia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GA"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GA: Gabon"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GN"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GN: Guinea"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GQ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GQ: Equatorial Guinea"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GY"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GY: Guyana"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HK"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "HK: Hong Kong"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ID"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "ID: Indonesia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "IN"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "IN: India"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "IQ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "IQ: Iraq"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "IR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "IR: Iran"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "JO"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "JO: Jordan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "KG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KG: Kyrgyzstan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "LB"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "LB: Lebanon"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "LY"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "LY: Libya"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MM: Myanmar"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MX"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MX: Mexico"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MY"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MY: Malaysia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MZ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MZ: Mozambique"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "NG: Nigeria"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "OM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "OM: Oman"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PA"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PA: Panama"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PH"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PH: Philippines"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PK"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PK: Pakistan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "QA"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "QA: Qatar"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RU"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "RU: Russia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SA"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SA: Saudi Arabia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SD"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SD: Sudan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SN"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SN: Senegal"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SY"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SY: Syria"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TH"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TH: Thailand"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TR: Turkey"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TW"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TW: Taiwan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TZ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TZ: Tanzania"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "UA"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "UA: Ukraine"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "UG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "UG: Uganda"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "US"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "US: United States"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "VE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "VE: Venezuela"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "YE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "YE: Yemen"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ZA"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "ZA: South Africa"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ZW"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "ZW: Zimbabwe"
+              }
+            ]
+          }
+        ]
       },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 20 },
+      "gridPos": {
+        "h": 16,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
       "id": 12,
       "options": {
-        "legend": { "calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "displayMode": "hidden",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "pluginVersion": "10.4.1",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum by (region) (conduit_region_connected_clients)", "legendFormat": "{{region}}", "refId": "A" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (region) (conduit_region_connected_clients)",
+          "legendFormat": "{{region}}",
+          "refId": "A"
+        }
       ],
       "title": "Connected Clients by Region",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "custom": {
             "align": "auto",
-            "cellOptions": { "type": "auto" },
+            "cellOptions": {
+              "type": "auto"
+            },
             "inspect": false
           },
-          "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "AE": {
+                  "text": "AE: United Arab Emirates",
+                  "index": 0
+                },
+                "AF": {
+                  "text": "AF: Afghanistan",
+                  "index": 1
+                },
+                "AR": {
+                  "text": "AR: Argentina",
+                  "index": 2
+                },
+                "AU": {
+                  "text": "AU: Australia",
+                  "index": 3
+                },
+                "BF": {
+                  "text": "BF: Burkina Faso",
+                  "index": 4
+                },
+                "BH": {
+                  "text": "BH: Bahrain",
+                  "index": 5
+                },
+                "BR": {
+                  "text": "BR: Brazil",
+                  "index": 6
+                },
+                "BY": {
+                  "text": "BY: Belarus",
+                  "index": 7
+                },
+                "CN": {
+                  "text": "CN: China",
+                  "index": 8
+                },
+                "CO": {
+                  "text": "CO: Colombia",
+                  "index": 9
+                },
+                "CU": {
+                  "text": "CU: Cuba",
+                  "index": 10
+                },
+                "DJ": {
+                  "text": "DJ: Djibouti",
+                  "index": 11
+                },
+                "DO": {
+                  "text": "DO: Dominican Republic",
+                  "index": 12
+                },
+                "EC": {
+                  "text": "EC: Ecuador",
+                  "index": 13
+                },
+                "EG": {
+                  "text": "EG: Egypt",
+                  "index": 14
+                },
+                "ET": {
+                  "text": "ET: Ethiopia",
+                  "index": 15
+                },
+                "GA": {
+                  "text": "GA: Gabon",
+                  "index": 16
+                },
+                "GN": {
+                  "text": "GN: Guinea",
+                  "index": 17
+                },
+                "GQ": {
+                  "text": "GQ: Equatorial Guinea",
+                  "index": 18
+                },
+                "GY": {
+                  "text": "GY: Guyana",
+                  "index": 19
+                },
+                "HK": {
+                  "text": "HK: Hong Kong",
+                  "index": 20
+                },
+                "ID": {
+                  "text": "ID: Indonesia",
+                  "index": 21
+                },
+                "IN": {
+                  "text": "IN: India",
+                  "index": 22
+                },
+                "IQ": {
+                  "text": "IQ: Iraq",
+                  "index": 23
+                },
+                "IR": {
+                  "text": "IR: Iran",
+                  "index": 24
+                },
+                "JO": {
+                  "text": "JO: Jordan",
+                  "index": 25
+                },
+                "KG": {
+                  "text": "KG: Kyrgyzstan",
+                  "index": 26
+                },
+                "LB": {
+                  "text": "LB: Lebanon",
+                  "index": 27
+                },
+                "LY": {
+                  "text": "LY: Libya",
+                  "index": 28
+                },
+                "MM": {
+                  "text": "MM: Myanmar",
+                  "index": 29
+                },
+                "MX": {
+                  "text": "MX: Mexico",
+                  "index": 30
+                },
+                "MY": {
+                  "text": "MY: Malaysia",
+                  "index": 31
+                },
+                "MZ": {
+                  "text": "MZ: Mozambique",
+                  "index": 32
+                },
+                "NG": {
+                  "text": "NG: Nigeria",
+                  "index": 33
+                },
+                "OM": {
+                  "text": "OM: Oman",
+                  "index": 34
+                },
+                "PA": {
+                  "text": "PA: Panama",
+                  "index": 35
+                },
+                "PH": {
+                  "text": "PH: Philippines",
+                  "index": 36
+                },
+                "PK": {
+                  "text": "PK: Pakistan",
+                  "index": 37
+                },
+                "QA": {
+                  "text": "QA: Qatar",
+                  "index": 38
+                },
+                "RU": {
+                  "text": "RU: Russia",
+                  "index": 39
+                },
+                "SA": {
+                  "text": "SA: Saudi Arabia",
+                  "index": 40
+                },
+                "SD": {
+                  "text": "SD: Sudan",
+                  "index": 41
+                },
+                "SN": {
+                  "text": "SN: Senegal",
+                  "index": 42
+                },
+                "SY": {
+                  "text": "SY: Syria",
+                  "index": 43
+                },
+                "TH": {
+                  "text": "TH: Thailand",
+                  "index": 44
+                },
+                "TR": {
+                  "text": "TR: Turkey",
+                  "index": 45
+                },
+                "TW": {
+                  "text": "TW: Taiwan",
+                  "index": 46
+                },
+                "TZ": {
+                  "text": "TZ: Tanzania",
+                  "index": 47
+                },
+                "UA": {
+                  "text": "UA: Ukraine",
+                  "index": 48
+                },
+                "UG": {
+                  "text": "UG: Uganda",
+                  "index": 49
+                },
+                "US": {
+                  "text": "US: United States",
+                  "index": 50
+                },
+                "VE": {
+                  "text": "VE: Venezuela",
+                  "index": 51
+                },
+                "YE": {
+                  "text": "YE: Yemen",
+                  "index": 52
+                },
+                "ZA": {
+                  "text": "ZA: South Africa",
+                  "index": 53
+                },
+                "ZW": {
+                  "text": "ZW: Zimbabwe",
+                  "index": 54
+                }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "Region" },
-            "properties": [{ "id": "custom.width", "value": 100 }]
+            "matcher": {
+              "id": "byName",
+              "options": "Region"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
           },
           {
-            "matcher": { "id": "byName", "options": "Download" },
-            "properties": [{ "id": "unit", "value": "bytes" }]
+            "matcher": {
+              "id": "byName",
+              "options": "Download"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
           },
           {
-            "matcher": { "id": "byName", "options": "Upload" },
-            "properties": [{ "id": "unit", "value": "bytes" }]
+            "matcher": {
+              "id": "byName",
+              "options": "Upload"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
           }
         ]
       },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 28 },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 46
+      },
       "id": 13,
       "options": {
         "showHeader": true,
         "cellHeight": "sm",
         "footer": {
           "show": true,
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "countRows": false,
-          "fields": ["Connected", "Download", "Upload"]
+          "fields": [
+            "Connected",
+            "Download",
+            "Upload"
+          ]
         },
-        "sortBy": [{ "displayName": "Connected", "desc": true }]
+        "sortBy": [
+          {
+            "displayName": "Connected",
+            "desc": true
+          }
+        ]
       },
       "pluginVersion": "10.4.1",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum by (region) (conduit_region_connected_clients)", "format": "table", "instant": true, "refId": "Connected" },
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum by (region) (conduit_region_bytes_downloaded)", "format": "table", "instant": true, "refId": "Download" },
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum by (region) (conduit_region_bytes_uploaded)", "format": "table", "instant": true, "refId": "Upload" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (region) (conduit_region_connected_clients)",
+          "format": "table",
+          "instant": true,
+          "refId": "Connected"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (region) (conduit_region_bytes_downloaded)",
+          "format": "table",
+          "instant": true,
+          "refId": "Download"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (region) (conduit_region_bytes_uploaded)",
+          "format": "table",
+          "instant": true,
+          "refId": "Upload"
+        }
       ],
       "title": "Traffic by Region",
       "description": "Current connected clients and cumulative traffic per region",
       "transformations": [
         {
           "id": "seriesToColumns",
-          "options": { "byField": "region" }
+          "options": {
+            "byField": "region"
+          }
         },
         {
           "id": "organize",
           "options": {
-            "excludeByName": { "Time": true, "Time 1": true, "Time 2": true, "Time 3": true },
+            "excludeByName": {
+              "Time": true,
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true
+            },
             "renameByName": {
               "region": "Region",
               "Value #Connected": "Connected",
@@ -439,13 +2159,321 @@
         }
       ],
       "type": "table"
+    },
+    {
+      "id": 14,
+      "title": "Connected Clients by Region \u2014 Stats",
+      "type": "table",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (region) (conduit_region_connected_clients)",
+          "legendFormat": "{{region}}",
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "reduce",
+          "options": {
+            "reducers": [
+              "mean",
+              "max",
+              "lastNotNull"
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "Field": "Region",
+              "Last *": "Last",
+              "lastNotNull": "Last"
+            }
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "AE": {
+                  "text": "AE: United Arab Emirates",
+                  "index": 0
+                },
+                "AF": {
+                  "text": "AF: Afghanistan",
+                  "index": 1
+                },
+                "AR": {
+                  "text": "AR: Argentina",
+                  "index": 2
+                },
+                "AU": {
+                  "text": "AU: Australia",
+                  "index": 3
+                },
+                "BF": {
+                  "text": "BF: Burkina Faso",
+                  "index": 4
+                },
+                "BH": {
+                  "text": "BH: Bahrain",
+                  "index": 5
+                },
+                "BR": {
+                  "text": "BR: Brazil",
+                  "index": 6
+                },
+                "BY": {
+                  "text": "BY: Belarus",
+                  "index": 7
+                },
+                "CN": {
+                  "text": "CN: China",
+                  "index": 8
+                },
+                "CO": {
+                  "text": "CO: Colombia",
+                  "index": 9
+                },
+                "CU": {
+                  "text": "CU: Cuba",
+                  "index": 10
+                },
+                "DJ": {
+                  "text": "DJ: Djibouti",
+                  "index": 11
+                },
+                "DO": {
+                  "text": "DO: Dominican Republic",
+                  "index": 12
+                },
+                "EC": {
+                  "text": "EC: Ecuador",
+                  "index": 13
+                },
+                "EG": {
+                  "text": "EG: Egypt",
+                  "index": 14
+                },
+                "ET": {
+                  "text": "ET: Ethiopia",
+                  "index": 15
+                },
+                "GA": {
+                  "text": "GA: Gabon",
+                  "index": 16
+                },
+                "GN": {
+                  "text": "GN: Guinea",
+                  "index": 17
+                },
+                "GQ": {
+                  "text": "GQ: Equatorial Guinea",
+                  "index": 18
+                },
+                "GY": {
+                  "text": "GY: Guyana",
+                  "index": 19
+                },
+                "HK": {
+                  "text": "HK: Hong Kong",
+                  "index": 20
+                },
+                "ID": {
+                  "text": "ID: Indonesia",
+                  "index": 21
+                },
+                "IN": {
+                  "text": "IN: India",
+                  "index": 22
+                },
+                "IQ": {
+                  "text": "IQ: Iraq",
+                  "index": 23
+                },
+                "IR": {
+                  "text": "IR: Iran",
+                  "index": 24
+                },
+                "JO": {
+                  "text": "JO: Jordan",
+                  "index": 25
+                },
+                "KG": {
+                  "text": "KG: Kyrgyzstan",
+                  "index": 26
+                },
+                "LB": {
+                  "text": "LB: Lebanon",
+                  "index": 27
+                },
+                "LY": {
+                  "text": "LY: Libya",
+                  "index": 28
+                },
+                "MM": {
+                  "text": "MM: Myanmar",
+                  "index": 29
+                },
+                "MX": {
+                  "text": "MX: Mexico",
+                  "index": 30
+                },
+                "MY": {
+                  "text": "MY: Malaysia",
+                  "index": 31
+                },
+                "MZ": {
+                  "text": "MZ: Mozambique",
+                  "index": 32
+                },
+                "NG": {
+                  "text": "NG: Nigeria",
+                  "index": 33
+                },
+                "OM": {
+                  "text": "OM: Oman",
+                  "index": 34
+                },
+                "PA": {
+                  "text": "PA: Panama",
+                  "index": 35
+                },
+                "PH": {
+                  "text": "PH: Philippines",
+                  "index": 36
+                },
+                "PK": {
+                  "text": "PK: Pakistan",
+                  "index": 37
+                },
+                "QA": {
+                  "text": "QA: Qatar",
+                  "index": 38
+                },
+                "RU": {
+                  "text": "RU: Russia",
+                  "index": 39
+                },
+                "SA": {
+                  "text": "SA: Saudi Arabia",
+                  "index": 40
+                },
+                "SD": {
+                  "text": "SD: Sudan",
+                  "index": 41
+                },
+                "SN": {
+                  "text": "SN: Senegal",
+                  "index": 42
+                },
+                "SY": {
+                  "text": "SY: Syria",
+                  "index": 43
+                },
+                "TH": {
+                  "text": "TH: Thailand",
+                  "index": 44
+                },
+                "TR": {
+                  "text": "TR: Turkey",
+                  "index": 45
+                },
+                "TW": {
+                  "text": "TW: Taiwan",
+                  "index": 46
+                },
+                "TZ": {
+                  "text": "TZ: Tanzania",
+                  "index": 47
+                },
+                "UA": {
+                  "text": "UA: Ukraine",
+                  "index": 48
+                },
+                "UG": {
+                  "text": "UG: Uganda",
+                  "index": 49
+                },
+                "US": {
+                  "text": "US: United States",
+                  "index": 50
+                },
+                "VE": {
+                  "text": "VE: Venezuela",
+                  "index": 51
+                },
+                "YE": {
+                  "text": "YE: Yemen",
+                  "index": 52
+                },
+                "ZA": {
+                  "text": "ZA: South Africa",
+                  "index": 53
+                },
+                "ZW": {
+                  "text": "ZW: Zimbabwe",
+                  "index": 54
+                }
+              }
+            }
+          ],
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "sortBy": [
+          {
+            "displayName": "Last",
+            "desc": true
+          }
+        ],
+        "footer": {
+          "show": false
+        }
+      }
     }
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["moav", "conduit", "psiphon"],
-  "templating": { "list": [] },
-  "time": { "from": "now-6h", "to": "now" },
+  "tags": [
+    "moav",
+    "conduit",
+    "psiphon"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "",
   "title": "MoaV - Conduit",

--- a/configs/monitoring/grafana/provisioning/dashboards/conduit.json
+++ b/configs/monitoring/grafana/provisioning/dashboards/conduit.json
@@ -847,257 +847,1001 @@
             {
               "type": "value",
               "options": {
+                "AD": {
+                  "text": "AD: Andorra",
+                  "index": 0
+                },
                 "AE": {
                   "text": "AE: United Arab Emirates",
-                  "index": 0
+                  "index": 1
                 },
                 "AF": {
                   "text": "AF: Afghanistan",
-                  "index": 1
+                  "index": 2
+                },
+                "AG": {
+                  "text": "AG: Antigua and Barbuda",
+                  "index": 3
+                },
+                "AI": {
+                  "text": "AI: Anguilla",
+                  "index": 4
+                },
+                "AL": {
+                  "text": "AL: Albania",
+                  "index": 5
+                },
+                "AM": {
+                  "text": "AM: Armenia",
+                  "index": 6
+                },
+                "AO": {
+                  "text": "AO: Angola",
+                  "index": 7
+                },
+                "AQ": {
+                  "text": "AQ: Antarctica",
+                  "index": 8
                 },
                 "AR": {
                   "text": "AR: Argentina",
-                  "index": 2
+                  "index": 9
+                },
+                "AS": {
+                  "text": "AS: American Samoa",
+                  "index": 10
+                },
+                "AT": {
+                  "text": "AT: Austria",
+                  "index": 11
                 },
                 "AU": {
                   "text": "AU: Australia",
-                  "index": 3
-                },
-                "BF": {
-                  "text": "BF: Burkina Faso",
-                  "index": 4
-                },
-                "BH": {
-                  "text": "BH: Bahrain",
-                  "index": 5
-                },
-                "BR": {
-                  "text": "BR: Brazil",
-                  "index": 6
-                },
-                "BY": {
-                  "text": "BY: Belarus",
-                  "index": 7
-                },
-                "CN": {
-                  "text": "CN: China",
-                  "index": 8
-                },
-                "CO": {
-                  "text": "CO: Colombia",
-                  "index": 9
-                },
-                "CU": {
-                  "text": "CU: Cuba",
-                  "index": 10
-                },
-                "DJ": {
-                  "text": "DJ: Djibouti",
-                  "index": 11
-                },
-                "DO": {
-                  "text": "DO: Dominican Republic",
                   "index": 12
                 },
-                "EC": {
-                  "text": "EC: Ecuador",
+                "AW": {
+                  "text": "AW: Aruba",
                   "index": 13
                 },
-                "EG": {
-                  "text": "EG: Egypt",
+                "AX": {
+                  "text": "AX: \u00c5land Islands",
                   "index": 14
-                },
-                "ET": {
-                  "text": "ET: Ethiopia",
-                  "index": 15
-                },
-                "GA": {
-                  "text": "GA: Gabon",
-                  "index": 16
-                },
-                "GN": {
-                  "text": "GN: Guinea",
-                  "index": 17
-                },
-                "GQ": {
-                  "text": "GQ: Equatorial Guinea",
-                  "index": 18
-                },
-                "GY": {
-                  "text": "GY: Guyana",
-                  "index": 19
-                },
-                "HK": {
-                  "text": "HK: Hong Kong",
-                  "index": 20
-                },
-                "ID": {
-                  "text": "ID: Indonesia",
-                  "index": 21
-                },
-                "IN": {
-                  "text": "IN: India",
-                  "index": 22
-                },
-                "IQ": {
-                  "text": "IQ: Iraq",
-                  "index": 23
-                },
-                "IR": {
-                  "text": "IR: Iran",
-                  "index": 24
-                },
-                "JO": {
-                  "text": "JO: Jordan",
-                  "index": 25
-                },
-                "KG": {
-                  "text": "KG: Kyrgyzstan",
-                  "index": 26
-                },
-                "LB": {
-                  "text": "LB: Lebanon",
-                  "index": 27
-                },
-                "LY": {
-                  "text": "LY: Libya",
-                  "index": 28
-                },
-                "MM": {
-                  "text": "MM: Myanmar",
-                  "index": 29
-                },
-                "MX": {
-                  "text": "MX: Mexico",
-                  "index": 30
-                },
-                "MY": {
-                  "text": "MY: Malaysia",
-                  "index": 31
-                },
-                "MZ": {
-                  "text": "MZ: Mozambique",
-                  "index": 32
-                },
-                "NG": {
-                  "text": "NG: Nigeria",
-                  "index": 33
-                },
-                "OM": {
-                  "text": "OM: Oman",
-                  "index": 34
-                },
-                "PA": {
-                  "text": "PA: Panama",
-                  "index": 35
-                },
-                "PH": {
-                  "text": "PH: Philippines",
-                  "index": 36
-                },
-                "PK": {
-                  "text": "PK: Pakistan",
-                  "index": 37
-                },
-                "QA": {
-                  "text": "QA: Qatar",
-                  "index": 38
-                },
-                "RU": {
-                  "text": "RU: Russia",
-                  "index": 39
-                },
-                "SA": {
-                  "text": "SA: Saudi Arabia",
-                  "index": 40
-                },
-                "SD": {
-                  "text": "SD: Sudan",
-                  "index": 41
-                },
-                "SN": {
-                  "text": "SN: Senegal",
-                  "index": 42
-                },
-                "SY": {
-                  "text": "SY: Syria",
-                  "index": 43
-                },
-                "TH": {
-                  "text": "TH: Thailand",
-                  "index": 44
-                },
-                "TR": {
-                  "text": "TR: Turkey",
-                  "index": 45
-                },
-                "TW": {
-                  "text": "TW: Taiwan",
-                  "index": 46
-                },
-                "TZ": {
-                  "text": "TZ: Tanzania",
-                  "index": 47
-                },
-                "UA": {
-                  "text": "UA: Ukraine",
-                  "index": 48
-                },
-                "UG": {
-                  "text": "UG: Uganda",
-                  "index": 49
-                },
-                "US": {
-                  "text": "US: United States",
-                  "index": 50
-                },
-                "VE": {
-                  "text": "VE: Venezuela",
-                  "index": 51
-                },
-                "YE": {
-                  "text": "YE: Yemen",
-                  "index": 52
-                },
-                "ZA": {
-                  "text": "ZA: South Africa",
-                  "index": 53
-                },
-                "ZW": {
-                  "text": "ZW: Zimbabwe",
-                  "index": 54
                 },
                 "AZ": {
                   "text": "AZ: Azerbaijan",
+                  "index": 15
+                },
+                "BA": {
+                  "text": "BA: Bosnia and Herzegovina",
+                  "index": 16
+                },
+                "BB": {
+                  "text": "BB: Barbados",
+                  "index": 17
+                },
+                "BD": {
+                  "text": "BD: Bangladesh",
+                  "index": 18
+                },
+                "BE": {
+                  "text": "BE: Belgium",
+                  "index": 19
+                },
+                "BF": {
+                  "text": "BF: Burkina Faso",
+                  "index": 20
+                },
+                "BG": {
+                  "text": "BG: Bulgaria",
+                  "index": 21
+                },
+                "BH": {
+                  "text": "BH: Bahrain",
+                  "index": 22
+                },
+                "BI": {
+                  "text": "BI: Burundi",
+                  "index": 23
+                },
+                "BJ": {
+                  "text": "BJ: Benin",
+                  "index": 24
+                },
+                "BL": {
+                  "text": "BL: Saint Barth\u00e9lemy",
+                  "index": 25
+                },
+                "BM": {
+                  "text": "BM: Bermuda",
+                  "index": 26
+                },
+                "BN": {
+                  "text": "BN: Brunei Darussalam",
+                  "index": 27
+                },
+                "BO": {
+                  "text": "BO: Bolivia, Plurinational State of",
+                  "index": 28
+                },
+                "BQ": {
+                  "text": "BQ: Bonaire, Sint Eustatius and Saba",
+                  "index": 29
+                },
+                "BR": {
+                  "text": "BR: Brazil",
+                  "index": 30
+                },
+                "BS": {
+                  "text": "BS: Bahamas",
+                  "index": 31
+                },
+                "BT": {
+                  "text": "BT: Bhutan",
+                  "index": 32
+                },
+                "BV": {
+                  "text": "BV: Bouvet Island",
+                  "index": 33
+                },
+                "BW": {
+                  "text": "BW: Botswana",
+                  "index": 34
+                },
+                "BY": {
+                  "text": "BY: Belarus",
+                  "index": 35
+                },
+                "BZ": {
+                  "text": "BZ: Belize",
+                  "index": 36
+                },
+                "CA": {
+                  "text": "CA: Canada",
+                  "index": 37
+                },
+                "CC": {
+                  "text": "CC: Cocos (Keeling) Islands",
+                  "index": 38
+                },
+                "CD": {
+                  "text": "CD: Congo, The Democratic Republic of the",
+                  "index": 39
+                },
+                "CF": {
+                  "text": "CF: Central African Republic",
+                  "index": 40
+                },
+                "CG": {
+                  "text": "CG: Congo",
+                  "index": 41
+                },
+                "CH": {
+                  "text": "CH: Switzerland",
+                  "index": 42
+                },
+                "CI": {
+                  "text": "CI: C\u00f4te d'Ivoire",
+                  "index": 43
+                },
+                "CK": {
+                  "text": "CK: Cook Islands",
+                  "index": 44
+                },
+                "CL": {
+                  "text": "CL: Chile",
+                  "index": 45
+                },
+                "CM": {
+                  "text": "CM: Cameroon",
+                  "index": 46
+                },
+                "CN": {
+                  "text": "CN: China",
+                  "index": 47
+                },
+                "CO": {
+                  "text": "CO: Colombia",
+                  "index": 48
+                },
+                "CR": {
+                  "text": "CR: Costa Rica",
+                  "index": 49
+                },
+                "CU": {
+                  "text": "CU: Cuba",
+                  "index": 50
+                },
+                "CV": {
+                  "text": "CV: Cabo Verde",
+                  "index": 51
+                },
+                "CW": {
+                  "text": "CW: Cura\u00e7ao",
+                  "index": 52
+                },
+                "CX": {
+                  "text": "CX: Christmas Island",
+                  "index": 53
+                },
+                "CY": {
+                  "text": "CY: Cyprus",
+                  "index": 54
+                },
+                "CZ": {
+                  "text": "CZ: Czechia",
                   "index": 55
+                },
+                "DE": {
+                  "text": "DE: Germany",
+                  "index": 56
+                },
+                "DJ": {
+                  "text": "DJ: Djibouti",
+                  "index": 57
+                },
+                "DK": {
+                  "text": "DK: Denmark",
+                  "index": 58
+                },
+                "DM": {
+                  "text": "DM: Dominica",
+                  "index": 59
+                },
+                "DO": {
+                  "text": "DO: Dominican Republic",
+                  "index": 60
+                },
+                "DZ": {
+                  "text": "DZ: Algeria",
+                  "index": 61
+                },
+                "EC": {
+                  "text": "EC: Ecuador",
+                  "index": 62
+                },
+                "EE": {
+                  "text": "EE: Estonia",
+                  "index": 63
+                },
+                "EG": {
+                  "text": "EG: Egypt",
+                  "index": 64
+                },
+                "EH": {
+                  "text": "EH: Western Sahara",
+                  "index": 65
+                },
+                "ER": {
+                  "text": "ER: Eritrea",
+                  "index": 66
+                },
+                "ES": {
+                  "text": "ES: Spain",
+                  "index": 67
+                },
+                "ET": {
+                  "text": "ET: Ethiopia",
+                  "index": 68
+                },
+                "FI": {
+                  "text": "FI: Finland",
+                  "index": 69
+                },
+                "FJ": {
+                  "text": "FJ: Fiji",
+                  "index": 70
+                },
+                "FK": {
+                  "text": "FK: Falkland Islands (Malvinas)",
+                  "index": 71
+                },
+                "FM": {
+                  "text": "FM: Micronesia, Federated States of",
+                  "index": 72
+                },
+                "FO": {
+                  "text": "FO: Faroe Islands",
+                  "index": 73
+                },
+                "FR": {
+                  "text": "FR: France",
+                  "index": 74
+                },
+                "GA": {
+                  "text": "GA: Gabon",
+                  "index": 75
+                },
+                "GB": {
+                  "text": "GB: United Kingdom",
+                  "index": 76
+                },
+                "GD": {
+                  "text": "GD: Grenada",
+                  "index": 77
+                },
+                "GE": {
+                  "text": "GE: Georgia",
+                  "index": 78
+                },
+                "GF": {
+                  "text": "GF: French Guiana",
+                  "index": 79
+                },
+                "GG": {
+                  "text": "GG: Guernsey",
+                  "index": 80
+                },
+                "GH": {
+                  "text": "GH: Ghana",
+                  "index": 81
+                },
+                "GI": {
+                  "text": "GI: Gibraltar",
+                  "index": 82
+                },
+                "GL": {
+                  "text": "GL: Greenland",
+                  "index": 83
+                },
+                "GM": {
+                  "text": "GM: Gambia",
+                  "index": 84
+                },
+                "GN": {
+                  "text": "GN: Guinea",
+                  "index": 85
+                },
+                "GP": {
+                  "text": "GP: Guadeloupe",
+                  "index": 86
+                },
+                "GQ": {
+                  "text": "GQ: Equatorial Guinea",
+                  "index": 87
+                },
+                "GR": {
+                  "text": "GR: Greece",
+                  "index": 88
+                },
+                "GS": {
+                  "text": "GS: South Georgia and the South Sandwich Islands",
+                  "index": 89
                 },
                 "GT": {
                   "text": "GT: Guatemala",
-                  "index": 56
+                  "index": 90
+                },
+                "GU": {
+                  "text": "GU: Guam",
+                  "index": 91
+                },
+                "GW": {
+                  "text": "GW: Guinea-Bissau",
+                  "index": 92
+                },
+                "GY": {
+                  "text": "GY: Guyana",
+                  "index": 93
+                },
+                "HK": {
+                  "text": "HK: Hong Kong",
+                  "index": 94
+                },
+                "HM": {
+                  "text": "HM: Heard Island and McDonald Islands",
+                  "index": 95
+                },
+                "HN": {
+                  "text": "HN: Honduras",
+                  "index": 96
+                },
+                "HR": {
+                  "text": "HR: Croatia",
+                  "index": 97
+                },
+                "HT": {
+                  "text": "HT: Haiti",
+                  "index": 98
+                },
+                "HU": {
+                  "text": "HU: Hungary",
+                  "index": 99
+                },
+                "ID": {
+                  "text": "ID: Indonesia",
+                  "index": 100
+                },
+                "IE": {
+                  "text": "IE: Ireland",
+                  "index": 101
+                },
+                "IL": {
+                  "text": "IL: Israel",
+                  "index": 102
+                },
+                "IM": {
+                  "text": "IM: Isle of Man",
+                  "index": 103
+                },
+                "IN": {
+                  "text": "IN: India",
+                  "index": 104
+                },
+                "IO": {
+                  "text": "IO: British Indian Ocean Territory",
+                  "index": 105
+                },
+                "IQ": {
+                  "text": "IQ: Iraq",
+                  "index": 106
+                },
+                "IR": {
+                  "text": "IR: Iran, Islamic Republic of",
+                  "index": 107
+                },
+                "IS": {
+                  "text": "IS: Iceland",
+                  "index": 108
+                },
+                "IT": {
+                  "text": "IT: Italy",
+                  "index": 109
+                },
+                "JE": {
+                  "text": "JE: Jersey",
+                  "index": 110
+                },
+                "JM": {
+                  "text": "JM: Jamaica",
+                  "index": 111
+                },
+                "JO": {
+                  "text": "JO: Jordan",
+                  "index": 112
+                },
+                "JP": {
+                  "text": "JP: Japan",
+                  "index": 113
                 },
                 "KE": {
                   "text": "KE: Kenya",
-                  "index": 57
+                  "index": 114
+                },
+                "KG": {
+                  "text": "KG: Kyrgyzstan",
+                  "index": 115
+                },
+                "KH": {
+                  "text": "KH: Cambodia",
+                  "index": 116
+                },
+                "KI": {
+                  "text": "KI: Kiribati",
+                  "index": 117
+                },
+                "KM": {
+                  "text": "KM: Comoros",
+                  "index": 118
+                },
+                "KN": {
+                  "text": "KN: Saint Kitts and Nevis",
+                  "index": 119
+                },
+                "KP": {
+                  "text": "KP: Korea, Democratic People's Republic of",
+                  "index": 120
+                },
+                "KR": {
+                  "text": "KR: Korea, Republic of",
+                  "index": 121
+                },
+                "KW": {
+                  "text": "KW: Kuwait",
+                  "index": 122
+                },
+                "KY": {
+                  "text": "KY: Cayman Islands",
+                  "index": 123
+                },
+                "KZ": {
+                  "text": "KZ: Kazakhstan",
+                  "index": 124
+                },
+                "LA": {
+                  "text": "LA: Lao People's Democratic Republic",
+                  "index": 125
+                },
+                "LB": {
+                  "text": "LB: Lebanon",
+                  "index": 126
+                },
+                "LC": {
+                  "text": "LC: Saint Lucia",
+                  "index": 127
+                },
+                "LI": {
+                  "text": "LI: Liechtenstein",
+                  "index": 128
+                },
+                "LK": {
+                  "text": "LK: Sri Lanka",
+                  "index": 129
+                },
+                "LR": {
+                  "text": "LR: Liberia",
+                  "index": 130
+                },
+                "LS": {
+                  "text": "LS: Lesotho",
+                  "index": 131
                 },
                 "LT": {
                   "text": "LT: Lithuania",
-                  "index": 58
+                  "index": 132
+                },
+                "LU": {
+                  "text": "LU: Luxembourg",
+                  "index": 133
+                },
+                "LV": {
+                  "text": "LV: Latvia",
+                  "index": 134
+                },
+                "LY": {
+                  "text": "LY: Libya",
+                  "index": 135
+                },
+                "MA": {
+                  "text": "MA: Morocco",
+                  "index": 136
+                },
+                "MC": {
+                  "text": "MC: Monaco",
+                  "index": 137
+                },
+                "MD": {
+                  "text": "MD: Moldova, Republic of",
+                  "index": 138
+                },
+                "ME": {
+                  "text": "ME: Montenegro",
+                  "index": 139
+                },
+                "MF": {
+                  "text": "MF: Saint Martin (French part)",
+                  "index": 140
+                },
+                "MG": {
+                  "text": "MG: Madagascar",
+                  "index": 141
+                },
+                "MH": {
+                  "text": "MH: Marshall Islands",
+                  "index": 142
+                },
+                "MK": {
+                  "text": "MK: North Macedonia",
+                  "index": 143
+                },
+                "ML": {
+                  "text": "ML: Mali",
+                  "index": 144
+                },
+                "MM": {
+                  "text": "MM: Myanmar",
+                  "index": 145
+                },
+                "MN": {
+                  "text": "MN: Mongolia",
+                  "index": 146
+                },
+                "MO": {
+                  "text": "MO: Macao",
+                  "index": 147
+                },
+                "MP": {
+                  "text": "MP: Northern Mariana Islands",
+                  "index": 148
+                },
+                "MQ": {
+                  "text": "MQ: Martinique",
+                  "index": 149
+                },
+                "MR": {
+                  "text": "MR: Mauritania",
+                  "index": 150
+                },
+                "MS": {
+                  "text": "MS: Montserrat",
+                  "index": 151
+                },
+                "MT": {
+                  "text": "MT: Malta",
+                  "index": 152
+                },
+                "MU": {
+                  "text": "MU: Mauritius",
+                  "index": 153
+                },
+                "MV": {
+                  "text": "MV: Maldives",
+                  "index": 154
+                },
+                "MW": {
+                  "text": "MW: Malawi",
+                  "index": 155
+                },
+                "MX": {
+                  "text": "MX: Mexico",
+                  "index": 156
+                },
+                "MY": {
+                  "text": "MY: Malaysia",
+                  "index": 157
+                },
+                "MZ": {
+                  "text": "MZ: Mozambique",
+                  "index": 158
+                },
+                "NA": {
+                  "text": "NA: Namibia",
+                  "index": 159
+                },
+                "NC": {
+                  "text": "NC: New Caledonia",
+                  "index": 160
+                },
+                "NE": {
+                  "text": "NE: Niger",
+                  "index": 161
+                },
+                "NF": {
+                  "text": "NF: Norfolk Island",
+                  "index": 162
+                },
+                "NG": {
+                  "text": "NG: Nigeria",
+                  "index": 163
+                },
+                "NI": {
+                  "text": "NI: Nicaragua",
+                  "index": 164
+                },
+                "NL": {
+                  "text": "NL: Netherlands",
+                  "index": 165
+                },
+                "NO": {
+                  "text": "NO: Norway",
+                  "index": 166
+                },
+                "NP": {
+                  "text": "NP: Nepal",
+                  "index": 167
+                },
+                "NR": {
+                  "text": "NR: Nauru",
+                  "index": 168
+                },
+                "NU": {
+                  "text": "NU: Niue",
+                  "index": 169
+                },
+                "NZ": {
+                  "text": "NZ: New Zealand",
+                  "index": 170
+                },
+                "OM": {
+                  "text": "OM: Oman",
+                  "index": 171
+                },
+                "PA": {
+                  "text": "PA: Panama",
+                  "index": 172
                 },
                 "PE": {
                   "text": "PE: Peru",
-                  "index": 59
+                  "index": 173
+                },
+                "PF": {
+                  "text": "PF: French Polynesia",
+                  "index": 174
+                },
+                "PG": {
+                  "text": "PG: Papua New Guinea",
+                  "index": 175
+                },
+                "PH": {
+                  "text": "PH: Philippines",
+                  "index": 176
+                },
+                "PK": {
+                  "text": "PK: Pakistan",
+                  "index": 177
+                },
+                "PL": {
+                  "text": "PL: Poland",
+                  "index": 178
+                },
+                "PM": {
+                  "text": "PM: Saint Pierre and Miquelon",
+                  "index": 179
+                },
+                "PN": {
+                  "text": "PN: Pitcairn",
+                  "index": 180
+                },
+                "PR": {
+                  "text": "PR: Puerto Rico",
+                  "index": 181
+                },
+                "PS": {
+                  "text": "PS: Palestine, State of",
+                  "index": 182
+                },
+                "PT": {
+                  "text": "PT: Portugal",
+                  "index": 183
+                },
+                "PW": {
+                  "text": "PW: Palau",
+                  "index": 184
+                },
+                "PY": {
+                  "text": "PY: Paraguay",
+                  "index": 185
+                },
+                "QA": {
+                  "text": "QA: Qatar",
+                  "index": 186
+                },
+                "RE": {
+                  "text": "RE: R\u00e9union",
+                  "index": 187
+                },
+                "RO": {
+                  "text": "RO: Romania",
+                  "index": 188
+                },
+                "RS": {
+                  "text": "RS: Serbia",
+                  "index": 189
+                },
+                "RU": {
+                  "text": "RU: Russian Federation",
+                  "index": 190
+                },
+                "RW": {
+                  "text": "RW: Rwanda",
+                  "index": 191
+                },
+                "SA": {
+                  "text": "SA: Saudi Arabia",
+                  "index": 192
+                },
+                "SB": {
+                  "text": "SB: Solomon Islands",
+                  "index": 193
+                },
+                "SC": {
+                  "text": "SC: Seychelles",
+                  "index": 194
+                },
+                "SD": {
+                  "text": "SD: Sudan",
+                  "index": 195
+                },
+                "SE": {
+                  "text": "SE: Sweden",
+                  "index": 196
                 },
                 "SG": {
                   "text": "SG: Singapore",
-                  "index": 60
+                  "index": 197
+                },
+                "SH": {
+                  "text": "SH: Saint Helena, Ascension and Tristan da Cunha",
+                  "index": 198
+                },
+                "SI": {
+                  "text": "SI: Slovenia",
+                  "index": 199
+                },
+                "SJ": {
+                  "text": "SJ: Svalbard and Jan Mayen",
+                  "index": 200
+                },
+                "SK": {
+                  "text": "SK: Slovakia",
+                  "index": 201
+                },
+                "SL": {
+                  "text": "SL: Sierra Leone",
+                  "index": 202
+                },
+                "SM": {
+                  "text": "SM: San Marino",
+                  "index": 203
+                },
+                "SN": {
+                  "text": "SN: Senegal",
+                  "index": 204
+                },
+                "SO": {
+                  "text": "SO: Somalia",
+                  "index": 205
+                },
+                "SR": {
+                  "text": "SR: Suriname",
+                  "index": 206
+                },
+                "SS": {
+                  "text": "SS: South Sudan",
+                  "index": 207
+                },
+                "ST": {
+                  "text": "ST: Sao Tome and Principe",
+                  "index": 208
+                },
+                "SV": {
+                  "text": "SV: El Salvador",
+                  "index": 209
+                },
+                "SX": {
+                  "text": "SX: Sint Maarten (Dutch part)",
+                  "index": 210
+                },
+                "SY": {
+                  "text": "SY: Syrian Arab Republic",
+                  "index": 211
+                },
+                "SZ": {
+                  "text": "SZ: Eswatini",
+                  "index": 212
+                },
+                "TC": {
+                  "text": "TC: Turks and Caicos Islands",
+                  "index": 213
+                },
+                "TD": {
+                  "text": "TD: Chad",
+                  "index": 214
+                },
+                "TF": {
+                  "text": "TF: French Southern Territories",
+                  "index": 215
+                },
+                "TG": {
+                  "text": "TG: Togo",
+                  "index": 216
+                },
+                "TH": {
+                  "text": "TH: Thailand",
+                  "index": 217
+                },
+                "TJ": {
+                  "text": "TJ: Tajikistan",
+                  "index": 218
+                },
+                "TK": {
+                  "text": "TK: Tokelau",
+                  "index": 219
+                },
+                "TL": {
+                  "text": "TL: Timor-Leste",
+                  "index": 220
+                },
+                "TM": {
+                  "text": "TM: Turkmenistan",
+                  "index": 221
                 },
                 "TN": {
                   "text": "TN: Tunisia",
-                  "index": 61
+                  "index": 222
+                },
+                "TO": {
+                  "text": "TO: Tonga",
+                  "index": 223
+                },
+                "TR": {
+                  "text": "TR: T\u00fcrkiye",
+                  "index": 224
+                },
+                "TT": {
+                  "text": "TT: Trinidad and Tobago",
+                  "index": 225
+                },
+                "TV": {
+                  "text": "TV: Tuvalu",
+                  "index": 226
+                },
+                "TW": {
+                  "text": "TW: Taiwan, Province of China",
+                  "index": 227
+                },
+                "TZ": {
+                  "text": "TZ: Tanzania, United Republic of",
+                  "index": 228
+                },
+                "UA": {
+                  "text": "UA: Ukraine",
+                  "index": 229
+                },
+                "UG": {
+                  "text": "UG: Uganda",
+                  "index": 230
+                },
+                "UM": {
+                  "text": "UM: United States Minor Outlying Islands",
+                  "index": 231
+                },
+                "US": {
+                  "text": "US: United States",
+                  "index": 232
+                },
+                "UY": {
+                  "text": "UY: Uruguay",
+                  "index": 233
                 },
                 "UZ": {
                   "text": "UZ: Uzbekistan",
-                  "index": 62
+                  "index": 234
+                },
+                "VA": {
+                  "text": "VA: Holy See (Vatican City State)",
+                  "index": 235
+                },
+                "VC": {
+                  "text": "VC: Saint Vincent and the Grenadines",
+                  "index": 236
+                },
+                "VE": {
+                  "text": "VE: Venezuela, Bolivarian Republic of",
+                  "index": 237
+                },
+                "VG": {
+                  "text": "VG: Virgin Islands, British",
+                  "index": 238
+                },
+                "VI": {
+                  "text": "VI: Virgin Islands, U.S.",
+                  "index": 239
+                },
+                "VN": {
+                  "text": "VN: Viet Nam",
+                  "index": 240
+                },
+                "VU": {
+                  "text": "VU: Vanuatu",
+                  "index": 241
+                },
+                "WF": {
+                  "text": "WF: Wallis and Futuna",
+                  "index": 242
+                },
+                "WS": {
+                  "text": "WS: Samoa",
+                  "index": 243
+                },
+                "YE": {
+                  "text": "YE: Yemen",
+                  "index": 244
+                },
+                "YT": {
+                  "text": "YT: Mayotte",
+                  "index": 245
+                },
+                "ZA": {
+                  "text": "ZA: South Africa",
+                  "index": 246
+                },
+                "ZM": {
+                  "text": "ZM: Zambia",
+                  "index": 247
+                },
+                "ZW": {
+                  "text": "ZW: Zimbabwe",
+                  "index": 248
                 }
               }
             }
@@ -1113,6 +1857,18 @@
           }
         },
         "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AD"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AD: Andorra"
+              }
+            ]
+          },
           {
             "matcher": {
               "id": "byName",
@@ -1140,12 +1896,108 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "AG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AG: Antigua and Barbuda"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AI"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AI: Anguilla"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AL"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AL: Albania"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AM: Armenia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AO"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AO: Angola"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AQ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AQ: Antarctica"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "AR"
             },
             "properties": [
               {
                 "id": "displayName",
                 "value": "AR: Argentina"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AS"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AS: American Samoa"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AT"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AT: Austria"
               }
             ]
           },
@@ -1164,12 +2016,108 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "AW"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AW: Aruba"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AX"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AX: \u00c5land Islands"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AZ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AZ: Azerbaijan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BA"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BA: Bosnia and Herzegovina"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BB"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BB: Barbados"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BD"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BD: Bangladesh"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BE: Belgium"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "BF"
             },
             "properties": [
               {
                 "id": "displayName",
                 "value": "BF: Burkina Faso"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BG: Bulgaria"
               }
             ]
           },
@@ -1188,6 +2136,90 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "BI"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BI: Burundi"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BJ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BJ: Benin"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BL"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BL: Saint Barth\u00e9lemy"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BM: Bermuda"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BN"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BN: Brunei Darussalam"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BO"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BO: Bolivia, Plurinational State of"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BQ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BQ: Bonaire, Sint Eustatius and Saba"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "BR"
             },
             "properties": [
@@ -1200,12 +2232,192 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "BS"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BS: Bahamas"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BT"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BT: Bhutan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BV"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BV: Bouvet Island"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BW"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BW: Botswana"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "BY"
             },
             "properties": [
               {
                 "id": "displayName",
                 "value": "BY: Belarus"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BZ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BZ: Belize"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CA"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CA: Canada"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CC: Cocos (Keeling) Islands"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CD"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CD: Congo, The Democratic Republic of the"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CF"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CF: Central African Republic"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CG: Congo"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CH"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CH: Switzerland"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CI"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CI: C\u00f4te d'Ivoire"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CK"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CK: Cook Islands"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CL"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CL: Chile"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CM: Cameroon"
               }
             ]
           },
@@ -1236,12 +2448,96 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "CR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CR: Costa Rica"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "CU"
             },
             "properties": [
               {
                 "id": "displayName",
                 "value": "CU: Cuba"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CV"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CV: Cabo Verde"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CW"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CW: Cura\u00e7ao"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CX"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CX: Christmas Island"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CY"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CY: Cyprus"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CZ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CZ: Czechia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "DE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "DE: Germany"
               }
             ]
           },
@@ -1260,12 +2556,48 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "DK"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "DK: Denmark"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "DM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "DM: Dominica"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "DO"
             },
             "properties": [
               {
                 "id": "displayName",
                 "value": "DO: Dominican Republic"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "DZ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "DZ: Algeria"
               }
             ]
           },
@@ -1284,12 +2616,60 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "EE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "EE: Estonia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "EG"
             },
             "properties": [
               {
                 "id": "displayName",
                 "value": "EG: Egypt"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "EH"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "EH: Western Sahara"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ER"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "ER: Eritrea"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ES"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "ES: Spain"
               }
             ]
           },
@@ -1308,12 +2688,192 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "FI"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "FI: Finland"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FJ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "FJ: Fiji"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FK"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "FK: Falkland Islands (Malvinas)"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "FM: Micronesia, Federated States of"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FO"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "FO: Faroe Islands"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "FR: France"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "GA"
             },
             "properties": [
               {
                 "id": "displayName",
                 "value": "GA: Gabon"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GB"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GB: United Kingdom"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GD"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GD: Grenada"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GE: Georgia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GF"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GF: French Guiana"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GG: Guernsey"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GH"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GH: Ghana"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GI"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GI: Gibraltar"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GL"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GL: Greenland"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GM: Gambia"
               }
             ]
           },
@@ -1332,12 +2892,84 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "GP"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GP: Guadeloupe"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "GQ"
             },
             "properties": [
               {
                 "id": "displayName",
                 "value": "GQ: Equatorial Guinea"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GR: Greece"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GS"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GS: South Georgia and the South Sandwich Islands"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GT"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GT: Guatemala"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GU"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GU: Guam"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GW"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GW: Guinea-Bissau"
               }
             ]
           },
@@ -1368,6 +3000,66 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "HM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "HM: Heard Island and McDonald Islands"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HN"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "HN: Honduras"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "HR: Croatia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HT"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "HT: Haiti"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HU"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "HU: Hungary"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "ID"
             },
             "properties": [
@@ -1380,12 +3072,60 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "IE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "IE: Ireland"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "IL"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "IL: Israel"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "IM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "IM: Isle of Man"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "IN"
             },
             "properties": [
               {
                 "id": "displayName",
                 "value": "IN: India"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "IO"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "IO: British Indian Ocean Territory"
               }
             ]
           },
@@ -1409,7 +3149,55 @@
             "properties": [
               {
                 "id": "displayName",
-                "value": "IR: Iran"
+                "value": "IR: Iran, Islamic Republic of"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "IS"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "IS: Iceland"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "IT"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "IT: Italy"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "JE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "JE: Jersey"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "JM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "JM: Jamaica"
               }
             ]
           },
@@ -1428,12 +3216,156 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "JP"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "JP: Japan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "KE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KE: Kenya"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "KG"
             },
             "properties": [
               {
                 "id": "displayName",
                 "value": "KG: Kyrgyzstan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "KH"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KH: Cambodia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "KI"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KI: Kiribati"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "KM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KM: Comoros"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "KN"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KN: Saint Kitts and Nevis"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "KP"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KP: Korea, Democratic People's Republic of"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "KR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KR: Korea, Republic of"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "KW"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KW: Kuwait"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "KY"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KY: Cayman Islands"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "KZ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KZ: Kazakhstan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "LA"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "LA: Lao People's Democratic Republic"
               }
             ]
           },
@@ -1452,6 +3384,102 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "LC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "LC: Saint Lucia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "LI"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "LI: Liechtenstein"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "LK"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "LK: Sri Lanka"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "LR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "LR: Liberia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "LS"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "LS: Lesotho"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "LT"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "LT: Lithuania"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "LU"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "LU: Luxembourg"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "LV"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "LV: Latvia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "LY"
             },
             "properties": [
@@ -1464,12 +3492,240 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "MA"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MA: Morocco"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MC: Monaco"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MD"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MD: Moldova, Republic of"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ME"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "ME: Montenegro"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MF"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MF: Saint Martin (French part)"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MG: Madagascar"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MH"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MH: Marshall Islands"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MK"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MK: North Macedonia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ML"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "ML: Mali"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "MM"
             },
             "properties": [
               {
                 "id": "displayName",
                 "value": "MM: Myanmar"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MN"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MN: Mongolia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MO"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MO: Macao"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MP"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MP: Northern Mariana Islands"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MQ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MQ: Martinique"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MR: Mauritania"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MS"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MS: Montserrat"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MT"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MT: Malta"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MU"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MU: Mauritius"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MV"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MV: Maldives"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MW"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MW: Malawi"
               }
             ]
           },
@@ -1512,12 +3768,144 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "NA"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "NA: Namibia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "NC: New Caledonia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "NE: Niger"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NF"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "NF: Norfolk Island"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "NG"
             },
             "properties": [
               {
                 "id": "displayName",
                 "value": "NG: Nigeria"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NI"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "NI: Nicaragua"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NL"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "NL: Netherlands"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NO"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "NO: Norway"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NP"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "NP: Nepal"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "NR: Nauru"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NU"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "NU: Niue"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NZ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "NZ: New Zealand"
               }
             ]
           },
@@ -1548,6 +3936,42 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "PE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PE: Peru"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PF"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PF: French Polynesia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PG: Papua New Guinea"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "PH"
             },
             "properties": [
@@ -1572,6 +3996,102 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "PL"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PL: Poland"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PM: Saint Pierre and Miquelon"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PN"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PN: Pitcairn"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PR: Puerto Rico"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PS"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PS: Palestine, State of"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PT"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PT: Portugal"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PW"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PW: Palau"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PY"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PY: Paraguay"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "QA"
             },
             "properties": [
@@ -1584,12 +4104,60 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "RE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "RE: R\u00e9union"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RO"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "RO: Romania"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RS"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "RS: Serbia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "RU"
             },
             "properties": [
               {
                 "id": "displayName",
-                "value": "RU: Russia"
+                "value": "RU: Russian Federation"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RW"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "RW: Rwanda"
               }
             ]
           },
@@ -1608,12 +4176,132 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "SB"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SB: Solomon Islands"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SC: Seychelles"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "SD"
             },
             "properties": [
               {
                 "id": "displayName",
                 "value": "SD: Sudan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SE: Sweden"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SG: Singapore"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SH"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SH: Saint Helena, Ascension and Tristan da Cunha"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SI"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SI: Slovenia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SJ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SJ: Svalbard and Jan Mayen"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SK"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SK: Slovakia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SL"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SL: Sierra Leone"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SM: San Marino"
               }
             ]
           },
@@ -1632,12 +4320,144 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "SO"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SO: Somalia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SR: Suriname"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SS"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SS: South Sudan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ST"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "ST: Sao Tome and Principe"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SV"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SV: El Salvador"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SX"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SX: Sint Maarten (Dutch part)"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "SY"
             },
             "properties": [
               {
                 "id": "displayName",
-                "value": "SY: Syria"
+                "value": "SY: Syrian Arab Republic"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SZ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SZ: Eswatini"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TC: Turks and Caicos Islands"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TD"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TD: Chad"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TF"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TF: French Southern Territories"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TG: Togo"
               }
             ]
           },
@@ -1656,12 +4476,108 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "TJ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TJ: Tajikistan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TK"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TK: Tokelau"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TL"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TL: Timor-Leste"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TM: Turkmenistan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TN"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TN: Tunisia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TO"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TO: Tonga"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "TR"
             },
             "properties": [
               {
                 "id": "displayName",
-                "value": "TR: Turkey"
+                "value": "TR: T\u00fcrkiye"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TT"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TT: Trinidad and Tobago"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TV"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TV: Tuvalu"
               }
             ]
           },
@@ -1673,7 +4589,7 @@
             "properties": [
               {
                 "id": "displayName",
-                "value": "TW: Taiwan"
+                "value": "TW: Taiwan, Province of China"
               }
             ]
           },
@@ -1685,7 +4601,7 @@
             "properties": [
               {
                 "id": "displayName",
-                "value": "TZ: Tanzania"
+                "value": "TZ: Tanzania, United Republic of"
               }
             ]
           },
@@ -1716,6 +4632,18 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "UM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "UM: United States Minor Outlying Islands"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "US"
             },
             "properties": [
@@ -1728,12 +4656,132 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "UY"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "UY: Uruguay"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "UZ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "UZ: Uzbekistan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "VA"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "VA: Holy See (Vatican City State)"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "VC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "VC: Saint Vincent and the Grenadines"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "VE"
             },
             "properties": [
               {
                 "id": "displayName",
-                "value": "VE: Venezuela"
+                "value": "VE: Venezuela, Bolivarian Republic of"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "VG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "VG: Virgin Islands, British"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "VI"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "VI: Virgin Islands, U.S."
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "VN"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "VN: Viet Nam"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "VU"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "VU: Vanuatu"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "WF"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "WF: Wallis and Futuna"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "WS"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "WS: Samoa"
               }
             ]
           },
@@ -1752,6 +4800,18 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "YT"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "YT: Mayotte"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "ZA"
             },
             "properties": [
@@ -1764,108 +4824,24 @@
           {
             "matcher": {
               "id": "byName",
+              "options": "ZM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "ZM: Zambia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
               "options": "ZW"
             },
             "properties": [
               {
                 "id": "displayName",
                 "value": "ZW: Zimbabwe"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "AZ"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "AZ: Azerbaijan"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "GT"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "GT: Guatemala"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "KE"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "KE: Kenya"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "LT"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "LT: Lithuania"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "PE"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "PE: Peru"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "SG"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "SG: Singapore"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "TN"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "TN: Tunisia"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "UZ"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "UZ: Uzbekistan"
               }
             ]
           }
@@ -1925,257 +4901,1001 @@
             {
               "type": "value",
               "options": {
+                "AD": {
+                  "text": "AD: Andorra",
+                  "index": 0
+                },
                 "AE": {
                   "text": "AE: United Arab Emirates",
-                  "index": 0
+                  "index": 1
                 },
                 "AF": {
                   "text": "AF: Afghanistan",
-                  "index": 1
+                  "index": 2
+                },
+                "AG": {
+                  "text": "AG: Antigua and Barbuda",
+                  "index": 3
+                },
+                "AI": {
+                  "text": "AI: Anguilla",
+                  "index": 4
+                },
+                "AL": {
+                  "text": "AL: Albania",
+                  "index": 5
+                },
+                "AM": {
+                  "text": "AM: Armenia",
+                  "index": 6
+                },
+                "AO": {
+                  "text": "AO: Angola",
+                  "index": 7
+                },
+                "AQ": {
+                  "text": "AQ: Antarctica",
+                  "index": 8
                 },
                 "AR": {
                   "text": "AR: Argentina",
-                  "index": 2
+                  "index": 9
+                },
+                "AS": {
+                  "text": "AS: American Samoa",
+                  "index": 10
+                },
+                "AT": {
+                  "text": "AT: Austria",
+                  "index": 11
                 },
                 "AU": {
                   "text": "AU: Australia",
-                  "index": 3
-                },
-                "BF": {
-                  "text": "BF: Burkina Faso",
-                  "index": 4
-                },
-                "BH": {
-                  "text": "BH: Bahrain",
-                  "index": 5
-                },
-                "BR": {
-                  "text": "BR: Brazil",
-                  "index": 6
-                },
-                "BY": {
-                  "text": "BY: Belarus",
-                  "index": 7
-                },
-                "CN": {
-                  "text": "CN: China",
-                  "index": 8
-                },
-                "CO": {
-                  "text": "CO: Colombia",
-                  "index": 9
-                },
-                "CU": {
-                  "text": "CU: Cuba",
-                  "index": 10
-                },
-                "DJ": {
-                  "text": "DJ: Djibouti",
-                  "index": 11
-                },
-                "DO": {
-                  "text": "DO: Dominican Republic",
                   "index": 12
                 },
-                "EC": {
-                  "text": "EC: Ecuador",
+                "AW": {
+                  "text": "AW: Aruba",
                   "index": 13
                 },
-                "EG": {
-                  "text": "EG: Egypt",
+                "AX": {
+                  "text": "AX: \u00c5land Islands",
                   "index": 14
-                },
-                "ET": {
-                  "text": "ET: Ethiopia",
-                  "index": 15
-                },
-                "GA": {
-                  "text": "GA: Gabon",
-                  "index": 16
-                },
-                "GN": {
-                  "text": "GN: Guinea",
-                  "index": 17
-                },
-                "GQ": {
-                  "text": "GQ: Equatorial Guinea",
-                  "index": 18
-                },
-                "GY": {
-                  "text": "GY: Guyana",
-                  "index": 19
-                },
-                "HK": {
-                  "text": "HK: Hong Kong",
-                  "index": 20
-                },
-                "ID": {
-                  "text": "ID: Indonesia",
-                  "index": 21
-                },
-                "IN": {
-                  "text": "IN: India",
-                  "index": 22
-                },
-                "IQ": {
-                  "text": "IQ: Iraq",
-                  "index": 23
-                },
-                "IR": {
-                  "text": "IR: Iran",
-                  "index": 24
-                },
-                "JO": {
-                  "text": "JO: Jordan",
-                  "index": 25
-                },
-                "KG": {
-                  "text": "KG: Kyrgyzstan",
-                  "index": 26
-                },
-                "LB": {
-                  "text": "LB: Lebanon",
-                  "index": 27
-                },
-                "LY": {
-                  "text": "LY: Libya",
-                  "index": 28
-                },
-                "MM": {
-                  "text": "MM: Myanmar",
-                  "index": 29
-                },
-                "MX": {
-                  "text": "MX: Mexico",
-                  "index": 30
-                },
-                "MY": {
-                  "text": "MY: Malaysia",
-                  "index": 31
-                },
-                "MZ": {
-                  "text": "MZ: Mozambique",
-                  "index": 32
-                },
-                "NG": {
-                  "text": "NG: Nigeria",
-                  "index": 33
-                },
-                "OM": {
-                  "text": "OM: Oman",
-                  "index": 34
-                },
-                "PA": {
-                  "text": "PA: Panama",
-                  "index": 35
-                },
-                "PH": {
-                  "text": "PH: Philippines",
-                  "index": 36
-                },
-                "PK": {
-                  "text": "PK: Pakistan",
-                  "index": 37
-                },
-                "QA": {
-                  "text": "QA: Qatar",
-                  "index": 38
-                },
-                "RU": {
-                  "text": "RU: Russia",
-                  "index": 39
-                },
-                "SA": {
-                  "text": "SA: Saudi Arabia",
-                  "index": 40
-                },
-                "SD": {
-                  "text": "SD: Sudan",
-                  "index": 41
-                },
-                "SN": {
-                  "text": "SN: Senegal",
-                  "index": 42
-                },
-                "SY": {
-                  "text": "SY: Syria",
-                  "index": 43
-                },
-                "TH": {
-                  "text": "TH: Thailand",
-                  "index": 44
-                },
-                "TR": {
-                  "text": "TR: Turkey",
-                  "index": 45
-                },
-                "TW": {
-                  "text": "TW: Taiwan",
-                  "index": 46
-                },
-                "TZ": {
-                  "text": "TZ: Tanzania",
-                  "index": 47
-                },
-                "UA": {
-                  "text": "UA: Ukraine",
-                  "index": 48
-                },
-                "UG": {
-                  "text": "UG: Uganda",
-                  "index": 49
-                },
-                "US": {
-                  "text": "US: United States",
-                  "index": 50
-                },
-                "VE": {
-                  "text": "VE: Venezuela",
-                  "index": 51
-                },
-                "YE": {
-                  "text": "YE: Yemen",
-                  "index": 52
-                },
-                "ZA": {
-                  "text": "ZA: South Africa",
-                  "index": 53
-                },
-                "ZW": {
-                  "text": "ZW: Zimbabwe",
-                  "index": 54
                 },
                 "AZ": {
                   "text": "AZ: Azerbaijan",
+                  "index": 15
+                },
+                "BA": {
+                  "text": "BA: Bosnia and Herzegovina",
+                  "index": 16
+                },
+                "BB": {
+                  "text": "BB: Barbados",
+                  "index": 17
+                },
+                "BD": {
+                  "text": "BD: Bangladesh",
+                  "index": 18
+                },
+                "BE": {
+                  "text": "BE: Belgium",
+                  "index": 19
+                },
+                "BF": {
+                  "text": "BF: Burkina Faso",
+                  "index": 20
+                },
+                "BG": {
+                  "text": "BG: Bulgaria",
+                  "index": 21
+                },
+                "BH": {
+                  "text": "BH: Bahrain",
+                  "index": 22
+                },
+                "BI": {
+                  "text": "BI: Burundi",
+                  "index": 23
+                },
+                "BJ": {
+                  "text": "BJ: Benin",
+                  "index": 24
+                },
+                "BL": {
+                  "text": "BL: Saint Barth\u00e9lemy",
+                  "index": 25
+                },
+                "BM": {
+                  "text": "BM: Bermuda",
+                  "index": 26
+                },
+                "BN": {
+                  "text": "BN: Brunei Darussalam",
+                  "index": 27
+                },
+                "BO": {
+                  "text": "BO: Bolivia, Plurinational State of",
+                  "index": 28
+                },
+                "BQ": {
+                  "text": "BQ: Bonaire, Sint Eustatius and Saba",
+                  "index": 29
+                },
+                "BR": {
+                  "text": "BR: Brazil",
+                  "index": 30
+                },
+                "BS": {
+                  "text": "BS: Bahamas",
+                  "index": 31
+                },
+                "BT": {
+                  "text": "BT: Bhutan",
+                  "index": 32
+                },
+                "BV": {
+                  "text": "BV: Bouvet Island",
+                  "index": 33
+                },
+                "BW": {
+                  "text": "BW: Botswana",
+                  "index": 34
+                },
+                "BY": {
+                  "text": "BY: Belarus",
+                  "index": 35
+                },
+                "BZ": {
+                  "text": "BZ: Belize",
+                  "index": 36
+                },
+                "CA": {
+                  "text": "CA: Canada",
+                  "index": 37
+                },
+                "CC": {
+                  "text": "CC: Cocos (Keeling) Islands",
+                  "index": 38
+                },
+                "CD": {
+                  "text": "CD: Congo, The Democratic Republic of the",
+                  "index": 39
+                },
+                "CF": {
+                  "text": "CF: Central African Republic",
+                  "index": 40
+                },
+                "CG": {
+                  "text": "CG: Congo",
+                  "index": 41
+                },
+                "CH": {
+                  "text": "CH: Switzerland",
+                  "index": 42
+                },
+                "CI": {
+                  "text": "CI: C\u00f4te d'Ivoire",
+                  "index": 43
+                },
+                "CK": {
+                  "text": "CK: Cook Islands",
+                  "index": 44
+                },
+                "CL": {
+                  "text": "CL: Chile",
+                  "index": 45
+                },
+                "CM": {
+                  "text": "CM: Cameroon",
+                  "index": 46
+                },
+                "CN": {
+                  "text": "CN: China",
+                  "index": 47
+                },
+                "CO": {
+                  "text": "CO: Colombia",
+                  "index": 48
+                },
+                "CR": {
+                  "text": "CR: Costa Rica",
+                  "index": 49
+                },
+                "CU": {
+                  "text": "CU: Cuba",
+                  "index": 50
+                },
+                "CV": {
+                  "text": "CV: Cabo Verde",
+                  "index": 51
+                },
+                "CW": {
+                  "text": "CW: Cura\u00e7ao",
+                  "index": 52
+                },
+                "CX": {
+                  "text": "CX: Christmas Island",
+                  "index": 53
+                },
+                "CY": {
+                  "text": "CY: Cyprus",
+                  "index": 54
+                },
+                "CZ": {
+                  "text": "CZ: Czechia",
                   "index": 55
+                },
+                "DE": {
+                  "text": "DE: Germany",
+                  "index": 56
+                },
+                "DJ": {
+                  "text": "DJ: Djibouti",
+                  "index": 57
+                },
+                "DK": {
+                  "text": "DK: Denmark",
+                  "index": 58
+                },
+                "DM": {
+                  "text": "DM: Dominica",
+                  "index": 59
+                },
+                "DO": {
+                  "text": "DO: Dominican Republic",
+                  "index": 60
+                },
+                "DZ": {
+                  "text": "DZ: Algeria",
+                  "index": 61
+                },
+                "EC": {
+                  "text": "EC: Ecuador",
+                  "index": 62
+                },
+                "EE": {
+                  "text": "EE: Estonia",
+                  "index": 63
+                },
+                "EG": {
+                  "text": "EG: Egypt",
+                  "index": 64
+                },
+                "EH": {
+                  "text": "EH: Western Sahara",
+                  "index": 65
+                },
+                "ER": {
+                  "text": "ER: Eritrea",
+                  "index": 66
+                },
+                "ES": {
+                  "text": "ES: Spain",
+                  "index": 67
+                },
+                "ET": {
+                  "text": "ET: Ethiopia",
+                  "index": 68
+                },
+                "FI": {
+                  "text": "FI: Finland",
+                  "index": 69
+                },
+                "FJ": {
+                  "text": "FJ: Fiji",
+                  "index": 70
+                },
+                "FK": {
+                  "text": "FK: Falkland Islands (Malvinas)",
+                  "index": 71
+                },
+                "FM": {
+                  "text": "FM: Micronesia, Federated States of",
+                  "index": 72
+                },
+                "FO": {
+                  "text": "FO: Faroe Islands",
+                  "index": 73
+                },
+                "FR": {
+                  "text": "FR: France",
+                  "index": 74
+                },
+                "GA": {
+                  "text": "GA: Gabon",
+                  "index": 75
+                },
+                "GB": {
+                  "text": "GB: United Kingdom",
+                  "index": 76
+                },
+                "GD": {
+                  "text": "GD: Grenada",
+                  "index": 77
+                },
+                "GE": {
+                  "text": "GE: Georgia",
+                  "index": 78
+                },
+                "GF": {
+                  "text": "GF: French Guiana",
+                  "index": 79
+                },
+                "GG": {
+                  "text": "GG: Guernsey",
+                  "index": 80
+                },
+                "GH": {
+                  "text": "GH: Ghana",
+                  "index": 81
+                },
+                "GI": {
+                  "text": "GI: Gibraltar",
+                  "index": 82
+                },
+                "GL": {
+                  "text": "GL: Greenland",
+                  "index": 83
+                },
+                "GM": {
+                  "text": "GM: Gambia",
+                  "index": 84
+                },
+                "GN": {
+                  "text": "GN: Guinea",
+                  "index": 85
+                },
+                "GP": {
+                  "text": "GP: Guadeloupe",
+                  "index": 86
+                },
+                "GQ": {
+                  "text": "GQ: Equatorial Guinea",
+                  "index": 87
+                },
+                "GR": {
+                  "text": "GR: Greece",
+                  "index": 88
+                },
+                "GS": {
+                  "text": "GS: South Georgia and the South Sandwich Islands",
+                  "index": 89
                 },
                 "GT": {
                   "text": "GT: Guatemala",
-                  "index": 56
+                  "index": 90
+                },
+                "GU": {
+                  "text": "GU: Guam",
+                  "index": 91
+                },
+                "GW": {
+                  "text": "GW: Guinea-Bissau",
+                  "index": 92
+                },
+                "GY": {
+                  "text": "GY: Guyana",
+                  "index": 93
+                },
+                "HK": {
+                  "text": "HK: Hong Kong",
+                  "index": 94
+                },
+                "HM": {
+                  "text": "HM: Heard Island and McDonald Islands",
+                  "index": 95
+                },
+                "HN": {
+                  "text": "HN: Honduras",
+                  "index": 96
+                },
+                "HR": {
+                  "text": "HR: Croatia",
+                  "index": 97
+                },
+                "HT": {
+                  "text": "HT: Haiti",
+                  "index": 98
+                },
+                "HU": {
+                  "text": "HU: Hungary",
+                  "index": 99
+                },
+                "ID": {
+                  "text": "ID: Indonesia",
+                  "index": 100
+                },
+                "IE": {
+                  "text": "IE: Ireland",
+                  "index": 101
+                },
+                "IL": {
+                  "text": "IL: Israel",
+                  "index": 102
+                },
+                "IM": {
+                  "text": "IM: Isle of Man",
+                  "index": 103
+                },
+                "IN": {
+                  "text": "IN: India",
+                  "index": 104
+                },
+                "IO": {
+                  "text": "IO: British Indian Ocean Territory",
+                  "index": 105
+                },
+                "IQ": {
+                  "text": "IQ: Iraq",
+                  "index": 106
+                },
+                "IR": {
+                  "text": "IR: Iran, Islamic Republic of",
+                  "index": 107
+                },
+                "IS": {
+                  "text": "IS: Iceland",
+                  "index": 108
+                },
+                "IT": {
+                  "text": "IT: Italy",
+                  "index": 109
+                },
+                "JE": {
+                  "text": "JE: Jersey",
+                  "index": 110
+                },
+                "JM": {
+                  "text": "JM: Jamaica",
+                  "index": 111
+                },
+                "JO": {
+                  "text": "JO: Jordan",
+                  "index": 112
+                },
+                "JP": {
+                  "text": "JP: Japan",
+                  "index": 113
                 },
                 "KE": {
                   "text": "KE: Kenya",
-                  "index": 57
+                  "index": 114
+                },
+                "KG": {
+                  "text": "KG: Kyrgyzstan",
+                  "index": 115
+                },
+                "KH": {
+                  "text": "KH: Cambodia",
+                  "index": 116
+                },
+                "KI": {
+                  "text": "KI: Kiribati",
+                  "index": 117
+                },
+                "KM": {
+                  "text": "KM: Comoros",
+                  "index": 118
+                },
+                "KN": {
+                  "text": "KN: Saint Kitts and Nevis",
+                  "index": 119
+                },
+                "KP": {
+                  "text": "KP: Korea, Democratic People's Republic of",
+                  "index": 120
+                },
+                "KR": {
+                  "text": "KR: Korea, Republic of",
+                  "index": 121
+                },
+                "KW": {
+                  "text": "KW: Kuwait",
+                  "index": 122
+                },
+                "KY": {
+                  "text": "KY: Cayman Islands",
+                  "index": 123
+                },
+                "KZ": {
+                  "text": "KZ: Kazakhstan",
+                  "index": 124
+                },
+                "LA": {
+                  "text": "LA: Lao People's Democratic Republic",
+                  "index": 125
+                },
+                "LB": {
+                  "text": "LB: Lebanon",
+                  "index": 126
+                },
+                "LC": {
+                  "text": "LC: Saint Lucia",
+                  "index": 127
+                },
+                "LI": {
+                  "text": "LI: Liechtenstein",
+                  "index": 128
+                },
+                "LK": {
+                  "text": "LK: Sri Lanka",
+                  "index": 129
+                },
+                "LR": {
+                  "text": "LR: Liberia",
+                  "index": 130
+                },
+                "LS": {
+                  "text": "LS: Lesotho",
+                  "index": 131
                 },
                 "LT": {
                   "text": "LT: Lithuania",
-                  "index": 58
+                  "index": 132
+                },
+                "LU": {
+                  "text": "LU: Luxembourg",
+                  "index": 133
+                },
+                "LV": {
+                  "text": "LV: Latvia",
+                  "index": 134
+                },
+                "LY": {
+                  "text": "LY: Libya",
+                  "index": 135
+                },
+                "MA": {
+                  "text": "MA: Morocco",
+                  "index": 136
+                },
+                "MC": {
+                  "text": "MC: Monaco",
+                  "index": 137
+                },
+                "MD": {
+                  "text": "MD: Moldova, Republic of",
+                  "index": 138
+                },
+                "ME": {
+                  "text": "ME: Montenegro",
+                  "index": 139
+                },
+                "MF": {
+                  "text": "MF: Saint Martin (French part)",
+                  "index": 140
+                },
+                "MG": {
+                  "text": "MG: Madagascar",
+                  "index": 141
+                },
+                "MH": {
+                  "text": "MH: Marshall Islands",
+                  "index": 142
+                },
+                "MK": {
+                  "text": "MK: North Macedonia",
+                  "index": 143
+                },
+                "ML": {
+                  "text": "ML: Mali",
+                  "index": 144
+                },
+                "MM": {
+                  "text": "MM: Myanmar",
+                  "index": 145
+                },
+                "MN": {
+                  "text": "MN: Mongolia",
+                  "index": 146
+                },
+                "MO": {
+                  "text": "MO: Macao",
+                  "index": 147
+                },
+                "MP": {
+                  "text": "MP: Northern Mariana Islands",
+                  "index": 148
+                },
+                "MQ": {
+                  "text": "MQ: Martinique",
+                  "index": 149
+                },
+                "MR": {
+                  "text": "MR: Mauritania",
+                  "index": 150
+                },
+                "MS": {
+                  "text": "MS: Montserrat",
+                  "index": 151
+                },
+                "MT": {
+                  "text": "MT: Malta",
+                  "index": 152
+                },
+                "MU": {
+                  "text": "MU: Mauritius",
+                  "index": 153
+                },
+                "MV": {
+                  "text": "MV: Maldives",
+                  "index": 154
+                },
+                "MW": {
+                  "text": "MW: Malawi",
+                  "index": 155
+                },
+                "MX": {
+                  "text": "MX: Mexico",
+                  "index": 156
+                },
+                "MY": {
+                  "text": "MY: Malaysia",
+                  "index": 157
+                },
+                "MZ": {
+                  "text": "MZ: Mozambique",
+                  "index": 158
+                },
+                "NA": {
+                  "text": "NA: Namibia",
+                  "index": 159
+                },
+                "NC": {
+                  "text": "NC: New Caledonia",
+                  "index": 160
+                },
+                "NE": {
+                  "text": "NE: Niger",
+                  "index": 161
+                },
+                "NF": {
+                  "text": "NF: Norfolk Island",
+                  "index": 162
+                },
+                "NG": {
+                  "text": "NG: Nigeria",
+                  "index": 163
+                },
+                "NI": {
+                  "text": "NI: Nicaragua",
+                  "index": 164
+                },
+                "NL": {
+                  "text": "NL: Netherlands",
+                  "index": 165
+                },
+                "NO": {
+                  "text": "NO: Norway",
+                  "index": 166
+                },
+                "NP": {
+                  "text": "NP: Nepal",
+                  "index": 167
+                },
+                "NR": {
+                  "text": "NR: Nauru",
+                  "index": 168
+                },
+                "NU": {
+                  "text": "NU: Niue",
+                  "index": 169
+                },
+                "NZ": {
+                  "text": "NZ: New Zealand",
+                  "index": 170
+                },
+                "OM": {
+                  "text": "OM: Oman",
+                  "index": 171
+                },
+                "PA": {
+                  "text": "PA: Panama",
+                  "index": 172
                 },
                 "PE": {
                   "text": "PE: Peru",
-                  "index": 59
+                  "index": 173
+                },
+                "PF": {
+                  "text": "PF: French Polynesia",
+                  "index": 174
+                },
+                "PG": {
+                  "text": "PG: Papua New Guinea",
+                  "index": 175
+                },
+                "PH": {
+                  "text": "PH: Philippines",
+                  "index": 176
+                },
+                "PK": {
+                  "text": "PK: Pakistan",
+                  "index": 177
+                },
+                "PL": {
+                  "text": "PL: Poland",
+                  "index": 178
+                },
+                "PM": {
+                  "text": "PM: Saint Pierre and Miquelon",
+                  "index": 179
+                },
+                "PN": {
+                  "text": "PN: Pitcairn",
+                  "index": 180
+                },
+                "PR": {
+                  "text": "PR: Puerto Rico",
+                  "index": 181
+                },
+                "PS": {
+                  "text": "PS: Palestine, State of",
+                  "index": 182
+                },
+                "PT": {
+                  "text": "PT: Portugal",
+                  "index": 183
+                },
+                "PW": {
+                  "text": "PW: Palau",
+                  "index": 184
+                },
+                "PY": {
+                  "text": "PY: Paraguay",
+                  "index": 185
+                },
+                "QA": {
+                  "text": "QA: Qatar",
+                  "index": 186
+                },
+                "RE": {
+                  "text": "RE: R\u00e9union",
+                  "index": 187
+                },
+                "RO": {
+                  "text": "RO: Romania",
+                  "index": 188
+                },
+                "RS": {
+                  "text": "RS: Serbia",
+                  "index": 189
+                },
+                "RU": {
+                  "text": "RU: Russian Federation",
+                  "index": 190
+                },
+                "RW": {
+                  "text": "RW: Rwanda",
+                  "index": 191
+                },
+                "SA": {
+                  "text": "SA: Saudi Arabia",
+                  "index": 192
+                },
+                "SB": {
+                  "text": "SB: Solomon Islands",
+                  "index": 193
+                },
+                "SC": {
+                  "text": "SC: Seychelles",
+                  "index": 194
+                },
+                "SD": {
+                  "text": "SD: Sudan",
+                  "index": 195
+                },
+                "SE": {
+                  "text": "SE: Sweden",
+                  "index": 196
                 },
                 "SG": {
                   "text": "SG: Singapore",
-                  "index": 60
+                  "index": 197
+                },
+                "SH": {
+                  "text": "SH: Saint Helena, Ascension and Tristan da Cunha",
+                  "index": 198
+                },
+                "SI": {
+                  "text": "SI: Slovenia",
+                  "index": 199
+                },
+                "SJ": {
+                  "text": "SJ: Svalbard and Jan Mayen",
+                  "index": 200
+                },
+                "SK": {
+                  "text": "SK: Slovakia",
+                  "index": 201
+                },
+                "SL": {
+                  "text": "SL: Sierra Leone",
+                  "index": 202
+                },
+                "SM": {
+                  "text": "SM: San Marino",
+                  "index": 203
+                },
+                "SN": {
+                  "text": "SN: Senegal",
+                  "index": 204
+                },
+                "SO": {
+                  "text": "SO: Somalia",
+                  "index": 205
+                },
+                "SR": {
+                  "text": "SR: Suriname",
+                  "index": 206
+                },
+                "SS": {
+                  "text": "SS: South Sudan",
+                  "index": 207
+                },
+                "ST": {
+                  "text": "ST: Sao Tome and Principe",
+                  "index": 208
+                },
+                "SV": {
+                  "text": "SV: El Salvador",
+                  "index": 209
+                },
+                "SX": {
+                  "text": "SX: Sint Maarten (Dutch part)",
+                  "index": 210
+                },
+                "SY": {
+                  "text": "SY: Syrian Arab Republic",
+                  "index": 211
+                },
+                "SZ": {
+                  "text": "SZ: Eswatini",
+                  "index": 212
+                },
+                "TC": {
+                  "text": "TC: Turks and Caicos Islands",
+                  "index": 213
+                },
+                "TD": {
+                  "text": "TD: Chad",
+                  "index": 214
+                },
+                "TF": {
+                  "text": "TF: French Southern Territories",
+                  "index": 215
+                },
+                "TG": {
+                  "text": "TG: Togo",
+                  "index": 216
+                },
+                "TH": {
+                  "text": "TH: Thailand",
+                  "index": 217
+                },
+                "TJ": {
+                  "text": "TJ: Tajikistan",
+                  "index": 218
+                },
+                "TK": {
+                  "text": "TK: Tokelau",
+                  "index": 219
+                },
+                "TL": {
+                  "text": "TL: Timor-Leste",
+                  "index": 220
+                },
+                "TM": {
+                  "text": "TM: Turkmenistan",
+                  "index": 221
                 },
                 "TN": {
                   "text": "TN: Tunisia",
-                  "index": 61
+                  "index": 222
+                },
+                "TO": {
+                  "text": "TO: Tonga",
+                  "index": 223
+                },
+                "TR": {
+                  "text": "TR: T\u00fcrkiye",
+                  "index": 224
+                },
+                "TT": {
+                  "text": "TT: Trinidad and Tobago",
+                  "index": 225
+                },
+                "TV": {
+                  "text": "TV: Tuvalu",
+                  "index": 226
+                },
+                "TW": {
+                  "text": "TW: Taiwan, Province of China",
+                  "index": 227
+                },
+                "TZ": {
+                  "text": "TZ: Tanzania, United Republic of",
+                  "index": 228
+                },
+                "UA": {
+                  "text": "UA: Ukraine",
+                  "index": 229
+                },
+                "UG": {
+                  "text": "UG: Uganda",
+                  "index": 230
+                },
+                "UM": {
+                  "text": "UM: United States Minor Outlying Islands",
+                  "index": 231
+                },
+                "US": {
+                  "text": "US: United States",
+                  "index": 232
+                },
+                "UY": {
+                  "text": "UY: Uruguay",
+                  "index": 233
                 },
                 "UZ": {
                   "text": "UZ: Uzbekistan",
-                  "index": 62
+                  "index": 234
+                },
+                "VA": {
+                  "text": "VA: Holy See (Vatican City State)",
+                  "index": 235
+                },
+                "VC": {
+                  "text": "VC: Saint Vincent and the Grenadines",
+                  "index": 236
+                },
+                "VE": {
+                  "text": "VE: Venezuela, Bolivarian Republic of",
+                  "index": 237
+                },
+                "VG": {
+                  "text": "VG: Virgin Islands, British",
+                  "index": 238
+                },
+                "VI": {
+                  "text": "VI: Virgin Islands, U.S.",
+                  "index": 239
+                },
+                "VN": {
+                  "text": "VN: Viet Nam",
+                  "index": 240
+                },
+                "VU": {
+                  "text": "VU: Vanuatu",
+                  "index": 241
+                },
+                "WF": {
+                  "text": "WF: Wallis and Futuna",
+                  "index": 242
+                },
+                "WS": {
+                  "text": "WS: Samoa",
+                  "index": 243
+                },
+                "YE": {
+                  "text": "YE: Yemen",
+                  "index": 244
+                },
+                "YT": {
+                  "text": "YT: Mayotte",
+                  "index": 245
+                },
+                "ZA": {
+                  "text": "ZA: South Africa",
+                  "index": 246
+                },
+                "ZM": {
+                  "text": "ZM: Zambia",
+                  "index": 247
+                },
+                "ZW": {
+                  "text": "ZW: Zimbabwe",
+                  "index": 248
                 }
               }
             }
@@ -2374,257 +6094,1001 @@
             {
               "type": "value",
               "options": {
+                "AD": {
+                  "text": "AD: Andorra",
+                  "index": 0
+                },
                 "AE": {
                   "text": "AE: United Arab Emirates",
-                  "index": 0
+                  "index": 1
                 },
                 "AF": {
                   "text": "AF: Afghanistan",
-                  "index": 1
+                  "index": 2
+                },
+                "AG": {
+                  "text": "AG: Antigua and Barbuda",
+                  "index": 3
+                },
+                "AI": {
+                  "text": "AI: Anguilla",
+                  "index": 4
+                },
+                "AL": {
+                  "text": "AL: Albania",
+                  "index": 5
+                },
+                "AM": {
+                  "text": "AM: Armenia",
+                  "index": 6
+                },
+                "AO": {
+                  "text": "AO: Angola",
+                  "index": 7
+                },
+                "AQ": {
+                  "text": "AQ: Antarctica",
+                  "index": 8
                 },
                 "AR": {
                   "text": "AR: Argentina",
-                  "index": 2
+                  "index": 9
+                },
+                "AS": {
+                  "text": "AS: American Samoa",
+                  "index": 10
+                },
+                "AT": {
+                  "text": "AT: Austria",
+                  "index": 11
                 },
                 "AU": {
                   "text": "AU: Australia",
-                  "index": 3
-                },
-                "BF": {
-                  "text": "BF: Burkina Faso",
-                  "index": 4
-                },
-                "BH": {
-                  "text": "BH: Bahrain",
-                  "index": 5
-                },
-                "BR": {
-                  "text": "BR: Brazil",
-                  "index": 6
-                },
-                "BY": {
-                  "text": "BY: Belarus",
-                  "index": 7
-                },
-                "CN": {
-                  "text": "CN: China",
-                  "index": 8
-                },
-                "CO": {
-                  "text": "CO: Colombia",
-                  "index": 9
-                },
-                "CU": {
-                  "text": "CU: Cuba",
-                  "index": 10
-                },
-                "DJ": {
-                  "text": "DJ: Djibouti",
-                  "index": 11
-                },
-                "DO": {
-                  "text": "DO: Dominican Republic",
                   "index": 12
                 },
-                "EC": {
-                  "text": "EC: Ecuador",
+                "AW": {
+                  "text": "AW: Aruba",
                   "index": 13
                 },
-                "EG": {
-                  "text": "EG: Egypt",
+                "AX": {
+                  "text": "AX: \u00c5land Islands",
                   "index": 14
-                },
-                "ET": {
-                  "text": "ET: Ethiopia",
-                  "index": 15
-                },
-                "GA": {
-                  "text": "GA: Gabon",
-                  "index": 16
-                },
-                "GN": {
-                  "text": "GN: Guinea",
-                  "index": 17
-                },
-                "GQ": {
-                  "text": "GQ: Equatorial Guinea",
-                  "index": 18
-                },
-                "GY": {
-                  "text": "GY: Guyana",
-                  "index": 19
-                },
-                "HK": {
-                  "text": "HK: Hong Kong",
-                  "index": 20
-                },
-                "ID": {
-                  "text": "ID: Indonesia",
-                  "index": 21
-                },
-                "IN": {
-                  "text": "IN: India",
-                  "index": 22
-                },
-                "IQ": {
-                  "text": "IQ: Iraq",
-                  "index": 23
-                },
-                "IR": {
-                  "text": "IR: Iran",
-                  "index": 24
-                },
-                "JO": {
-                  "text": "JO: Jordan",
-                  "index": 25
-                },
-                "KG": {
-                  "text": "KG: Kyrgyzstan",
-                  "index": 26
-                },
-                "LB": {
-                  "text": "LB: Lebanon",
-                  "index": 27
-                },
-                "LY": {
-                  "text": "LY: Libya",
-                  "index": 28
-                },
-                "MM": {
-                  "text": "MM: Myanmar",
-                  "index": 29
-                },
-                "MX": {
-                  "text": "MX: Mexico",
-                  "index": 30
-                },
-                "MY": {
-                  "text": "MY: Malaysia",
-                  "index": 31
-                },
-                "MZ": {
-                  "text": "MZ: Mozambique",
-                  "index": 32
-                },
-                "NG": {
-                  "text": "NG: Nigeria",
-                  "index": 33
-                },
-                "OM": {
-                  "text": "OM: Oman",
-                  "index": 34
-                },
-                "PA": {
-                  "text": "PA: Panama",
-                  "index": 35
-                },
-                "PH": {
-                  "text": "PH: Philippines",
-                  "index": 36
-                },
-                "PK": {
-                  "text": "PK: Pakistan",
-                  "index": 37
-                },
-                "QA": {
-                  "text": "QA: Qatar",
-                  "index": 38
-                },
-                "RU": {
-                  "text": "RU: Russia",
-                  "index": 39
-                },
-                "SA": {
-                  "text": "SA: Saudi Arabia",
-                  "index": 40
-                },
-                "SD": {
-                  "text": "SD: Sudan",
-                  "index": 41
-                },
-                "SN": {
-                  "text": "SN: Senegal",
-                  "index": 42
-                },
-                "SY": {
-                  "text": "SY: Syria",
-                  "index": 43
-                },
-                "TH": {
-                  "text": "TH: Thailand",
-                  "index": 44
-                },
-                "TR": {
-                  "text": "TR: Turkey",
-                  "index": 45
-                },
-                "TW": {
-                  "text": "TW: Taiwan",
-                  "index": 46
-                },
-                "TZ": {
-                  "text": "TZ: Tanzania",
-                  "index": 47
-                },
-                "UA": {
-                  "text": "UA: Ukraine",
-                  "index": 48
-                },
-                "UG": {
-                  "text": "UG: Uganda",
-                  "index": 49
-                },
-                "US": {
-                  "text": "US: United States",
-                  "index": 50
-                },
-                "VE": {
-                  "text": "VE: Venezuela",
-                  "index": 51
-                },
-                "YE": {
-                  "text": "YE: Yemen",
-                  "index": 52
-                },
-                "ZA": {
-                  "text": "ZA: South Africa",
-                  "index": 53
-                },
-                "ZW": {
-                  "text": "ZW: Zimbabwe",
-                  "index": 54
                 },
                 "AZ": {
                   "text": "AZ: Azerbaijan",
+                  "index": 15
+                },
+                "BA": {
+                  "text": "BA: Bosnia and Herzegovina",
+                  "index": 16
+                },
+                "BB": {
+                  "text": "BB: Barbados",
+                  "index": 17
+                },
+                "BD": {
+                  "text": "BD: Bangladesh",
+                  "index": 18
+                },
+                "BE": {
+                  "text": "BE: Belgium",
+                  "index": 19
+                },
+                "BF": {
+                  "text": "BF: Burkina Faso",
+                  "index": 20
+                },
+                "BG": {
+                  "text": "BG: Bulgaria",
+                  "index": 21
+                },
+                "BH": {
+                  "text": "BH: Bahrain",
+                  "index": 22
+                },
+                "BI": {
+                  "text": "BI: Burundi",
+                  "index": 23
+                },
+                "BJ": {
+                  "text": "BJ: Benin",
+                  "index": 24
+                },
+                "BL": {
+                  "text": "BL: Saint Barth\u00e9lemy",
+                  "index": 25
+                },
+                "BM": {
+                  "text": "BM: Bermuda",
+                  "index": 26
+                },
+                "BN": {
+                  "text": "BN: Brunei Darussalam",
+                  "index": 27
+                },
+                "BO": {
+                  "text": "BO: Bolivia, Plurinational State of",
+                  "index": 28
+                },
+                "BQ": {
+                  "text": "BQ: Bonaire, Sint Eustatius and Saba",
+                  "index": 29
+                },
+                "BR": {
+                  "text": "BR: Brazil",
+                  "index": 30
+                },
+                "BS": {
+                  "text": "BS: Bahamas",
+                  "index": 31
+                },
+                "BT": {
+                  "text": "BT: Bhutan",
+                  "index": 32
+                },
+                "BV": {
+                  "text": "BV: Bouvet Island",
+                  "index": 33
+                },
+                "BW": {
+                  "text": "BW: Botswana",
+                  "index": 34
+                },
+                "BY": {
+                  "text": "BY: Belarus",
+                  "index": 35
+                },
+                "BZ": {
+                  "text": "BZ: Belize",
+                  "index": 36
+                },
+                "CA": {
+                  "text": "CA: Canada",
+                  "index": 37
+                },
+                "CC": {
+                  "text": "CC: Cocos (Keeling) Islands",
+                  "index": 38
+                },
+                "CD": {
+                  "text": "CD: Congo, The Democratic Republic of the",
+                  "index": 39
+                },
+                "CF": {
+                  "text": "CF: Central African Republic",
+                  "index": 40
+                },
+                "CG": {
+                  "text": "CG: Congo",
+                  "index": 41
+                },
+                "CH": {
+                  "text": "CH: Switzerland",
+                  "index": 42
+                },
+                "CI": {
+                  "text": "CI: C\u00f4te d'Ivoire",
+                  "index": 43
+                },
+                "CK": {
+                  "text": "CK: Cook Islands",
+                  "index": 44
+                },
+                "CL": {
+                  "text": "CL: Chile",
+                  "index": 45
+                },
+                "CM": {
+                  "text": "CM: Cameroon",
+                  "index": 46
+                },
+                "CN": {
+                  "text": "CN: China",
+                  "index": 47
+                },
+                "CO": {
+                  "text": "CO: Colombia",
+                  "index": 48
+                },
+                "CR": {
+                  "text": "CR: Costa Rica",
+                  "index": 49
+                },
+                "CU": {
+                  "text": "CU: Cuba",
+                  "index": 50
+                },
+                "CV": {
+                  "text": "CV: Cabo Verde",
+                  "index": 51
+                },
+                "CW": {
+                  "text": "CW: Cura\u00e7ao",
+                  "index": 52
+                },
+                "CX": {
+                  "text": "CX: Christmas Island",
+                  "index": 53
+                },
+                "CY": {
+                  "text": "CY: Cyprus",
+                  "index": 54
+                },
+                "CZ": {
+                  "text": "CZ: Czechia",
                   "index": 55
+                },
+                "DE": {
+                  "text": "DE: Germany",
+                  "index": 56
+                },
+                "DJ": {
+                  "text": "DJ: Djibouti",
+                  "index": 57
+                },
+                "DK": {
+                  "text": "DK: Denmark",
+                  "index": 58
+                },
+                "DM": {
+                  "text": "DM: Dominica",
+                  "index": 59
+                },
+                "DO": {
+                  "text": "DO: Dominican Republic",
+                  "index": 60
+                },
+                "DZ": {
+                  "text": "DZ: Algeria",
+                  "index": 61
+                },
+                "EC": {
+                  "text": "EC: Ecuador",
+                  "index": 62
+                },
+                "EE": {
+                  "text": "EE: Estonia",
+                  "index": 63
+                },
+                "EG": {
+                  "text": "EG: Egypt",
+                  "index": 64
+                },
+                "EH": {
+                  "text": "EH: Western Sahara",
+                  "index": 65
+                },
+                "ER": {
+                  "text": "ER: Eritrea",
+                  "index": 66
+                },
+                "ES": {
+                  "text": "ES: Spain",
+                  "index": 67
+                },
+                "ET": {
+                  "text": "ET: Ethiopia",
+                  "index": 68
+                },
+                "FI": {
+                  "text": "FI: Finland",
+                  "index": 69
+                },
+                "FJ": {
+                  "text": "FJ: Fiji",
+                  "index": 70
+                },
+                "FK": {
+                  "text": "FK: Falkland Islands (Malvinas)",
+                  "index": 71
+                },
+                "FM": {
+                  "text": "FM: Micronesia, Federated States of",
+                  "index": 72
+                },
+                "FO": {
+                  "text": "FO: Faroe Islands",
+                  "index": 73
+                },
+                "FR": {
+                  "text": "FR: France",
+                  "index": 74
+                },
+                "GA": {
+                  "text": "GA: Gabon",
+                  "index": 75
+                },
+                "GB": {
+                  "text": "GB: United Kingdom",
+                  "index": 76
+                },
+                "GD": {
+                  "text": "GD: Grenada",
+                  "index": 77
+                },
+                "GE": {
+                  "text": "GE: Georgia",
+                  "index": 78
+                },
+                "GF": {
+                  "text": "GF: French Guiana",
+                  "index": 79
+                },
+                "GG": {
+                  "text": "GG: Guernsey",
+                  "index": 80
+                },
+                "GH": {
+                  "text": "GH: Ghana",
+                  "index": 81
+                },
+                "GI": {
+                  "text": "GI: Gibraltar",
+                  "index": 82
+                },
+                "GL": {
+                  "text": "GL: Greenland",
+                  "index": 83
+                },
+                "GM": {
+                  "text": "GM: Gambia",
+                  "index": 84
+                },
+                "GN": {
+                  "text": "GN: Guinea",
+                  "index": 85
+                },
+                "GP": {
+                  "text": "GP: Guadeloupe",
+                  "index": 86
+                },
+                "GQ": {
+                  "text": "GQ: Equatorial Guinea",
+                  "index": 87
+                },
+                "GR": {
+                  "text": "GR: Greece",
+                  "index": 88
+                },
+                "GS": {
+                  "text": "GS: South Georgia and the South Sandwich Islands",
+                  "index": 89
                 },
                 "GT": {
                   "text": "GT: Guatemala",
-                  "index": 56
+                  "index": 90
+                },
+                "GU": {
+                  "text": "GU: Guam",
+                  "index": 91
+                },
+                "GW": {
+                  "text": "GW: Guinea-Bissau",
+                  "index": 92
+                },
+                "GY": {
+                  "text": "GY: Guyana",
+                  "index": 93
+                },
+                "HK": {
+                  "text": "HK: Hong Kong",
+                  "index": 94
+                },
+                "HM": {
+                  "text": "HM: Heard Island and McDonald Islands",
+                  "index": 95
+                },
+                "HN": {
+                  "text": "HN: Honduras",
+                  "index": 96
+                },
+                "HR": {
+                  "text": "HR: Croatia",
+                  "index": 97
+                },
+                "HT": {
+                  "text": "HT: Haiti",
+                  "index": 98
+                },
+                "HU": {
+                  "text": "HU: Hungary",
+                  "index": 99
+                },
+                "ID": {
+                  "text": "ID: Indonesia",
+                  "index": 100
+                },
+                "IE": {
+                  "text": "IE: Ireland",
+                  "index": 101
+                },
+                "IL": {
+                  "text": "IL: Israel",
+                  "index": 102
+                },
+                "IM": {
+                  "text": "IM: Isle of Man",
+                  "index": 103
+                },
+                "IN": {
+                  "text": "IN: India",
+                  "index": 104
+                },
+                "IO": {
+                  "text": "IO: British Indian Ocean Territory",
+                  "index": 105
+                },
+                "IQ": {
+                  "text": "IQ: Iraq",
+                  "index": 106
+                },
+                "IR": {
+                  "text": "IR: Iran, Islamic Republic of",
+                  "index": 107
+                },
+                "IS": {
+                  "text": "IS: Iceland",
+                  "index": 108
+                },
+                "IT": {
+                  "text": "IT: Italy",
+                  "index": 109
+                },
+                "JE": {
+                  "text": "JE: Jersey",
+                  "index": 110
+                },
+                "JM": {
+                  "text": "JM: Jamaica",
+                  "index": 111
+                },
+                "JO": {
+                  "text": "JO: Jordan",
+                  "index": 112
+                },
+                "JP": {
+                  "text": "JP: Japan",
+                  "index": 113
                 },
                 "KE": {
                   "text": "KE: Kenya",
-                  "index": 57
+                  "index": 114
+                },
+                "KG": {
+                  "text": "KG: Kyrgyzstan",
+                  "index": 115
+                },
+                "KH": {
+                  "text": "KH: Cambodia",
+                  "index": 116
+                },
+                "KI": {
+                  "text": "KI: Kiribati",
+                  "index": 117
+                },
+                "KM": {
+                  "text": "KM: Comoros",
+                  "index": 118
+                },
+                "KN": {
+                  "text": "KN: Saint Kitts and Nevis",
+                  "index": 119
+                },
+                "KP": {
+                  "text": "KP: Korea, Democratic People's Republic of",
+                  "index": 120
+                },
+                "KR": {
+                  "text": "KR: Korea, Republic of",
+                  "index": 121
+                },
+                "KW": {
+                  "text": "KW: Kuwait",
+                  "index": 122
+                },
+                "KY": {
+                  "text": "KY: Cayman Islands",
+                  "index": 123
+                },
+                "KZ": {
+                  "text": "KZ: Kazakhstan",
+                  "index": 124
+                },
+                "LA": {
+                  "text": "LA: Lao People's Democratic Republic",
+                  "index": 125
+                },
+                "LB": {
+                  "text": "LB: Lebanon",
+                  "index": 126
+                },
+                "LC": {
+                  "text": "LC: Saint Lucia",
+                  "index": 127
+                },
+                "LI": {
+                  "text": "LI: Liechtenstein",
+                  "index": 128
+                },
+                "LK": {
+                  "text": "LK: Sri Lanka",
+                  "index": 129
+                },
+                "LR": {
+                  "text": "LR: Liberia",
+                  "index": 130
+                },
+                "LS": {
+                  "text": "LS: Lesotho",
+                  "index": 131
                 },
                 "LT": {
                   "text": "LT: Lithuania",
-                  "index": 58
+                  "index": 132
+                },
+                "LU": {
+                  "text": "LU: Luxembourg",
+                  "index": 133
+                },
+                "LV": {
+                  "text": "LV: Latvia",
+                  "index": 134
+                },
+                "LY": {
+                  "text": "LY: Libya",
+                  "index": 135
+                },
+                "MA": {
+                  "text": "MA: Morocco",
+                  "index": 136
+                },
+                "MC": {
+                  "text": "MC: Monaco",
+                  "index": 137
+                },
+                "MD": {
+                  "text": "MD: Moldova, Republic of",
+                  "index": 138
+                },
+                "ME": {
+                  "text": "ME: Montenegro",
+                  "index": 139
+                },
+                "MF": {
+                  "text": "MF: Saint Martin (French part)",
+                  "index": 140
+                },
+                "MG": {
+                  "text": "MG: Madagascar",
+                  "index": 141
+                },
+                "MH": {
+                  "text": "MH: Marshall Islands",
+                  "index": 142
+                },
+                "MK": {
+                  "text": "MK: North Macedonia",
+                  "index": 143
+                },
+                "ML": {
+                  "text": "ML: Mali",
+                  "index": 144
+                },
+                "MM": {
+                  "text": "MM: Myanmar",
+                  "index": 145
+                },
+                "MN": {
+                  "text": "MN: Mongolia",
+                  "index": 146
+                },
+                "MO": {
+                  "text": "MO: Macao",
+                  "index": 147
+                },
+                "MP": {
+                  "text": "MP: Northern Mariana Islands",
+                  "index": 148
+                },
+                "MQ": {
+                  "text": "MQ: Martinique",
+                  "index": 149
+                },
+                "MR": {
+                  "text": "MR: Mauritania",
+                  "index": 150
+                },
+                "MS": {
+                  "text": "MS: Montserrat",
+                  "index": 151
+                },
+                "MT": {
+                  "text": "MT: Malta",
+                  "index": 152
+                },
+                "MU": {
+                  "text": "MU: Mauritius",
+                  "index": 153
+                },
+                "MV": {
+                  "text": "MV: Maldives",
+                  "index": 154
+                },
+                "MW": {
+                  "text": "MW: Malawi",
+                  "index": 155
+                },
+                "MX": {
+                  "text": "MX: Mexico",
+                  "index": 156
+                },
+                "MY": {
+                  "text": "MY: Malaysia",
+                  "index": 157
+                },
+                "MZ": {
+                  "text": "MZ: Mozambique",
+                  "index": 158
+                },
+                "NA": {
+                  "text": "NA: Namibia",
+                  "index": 159
+                },
+                "NC": {
+                  "text": "NC: New Caledonia",
+                  "index": 160
+                },
+                "NE": {
+                  "text": "NE: Niger",
+                  "index": 161
+                },
+                "NF": {
+                  "text": "NF: Norfolk Island",
+                  "index": 162
+                },
+                "NG": {
+                  "text": "NG: Nigeria",
+                  "index": 163
+                },
+                "NI": {
+                  "text": "NI: Nicaragua",
+                  "index": 164
+                },
+                "NL": {
+                  "text": "NL: Netherlands",
+                  "index": 165
+                },
+                "NO": {
+                  "text": "NO: Norway",
+                  "index": 166
+                },
+                "NP": {
+                  "text": "NP: Nepal",
+                  "index": 167
+                },
+                "NR": {
+                  "text": "NR: Nauru",
+                  "index": 168
+                },
+                "NU": {
+                  "text": "NU: Niue",
+                  "index": 169
+                },
+                "NZ": {
+                  "text": "NZ: New Zealand",
+                  "index": 170
+                },
+                "OM": {
+                  "text": "OM: Oman",
+                  "index": 171
+                },
+                "PA": {
+                  "text": "PA: Panama",
+                  "index": 172
                 },
                 "PE": {
                   "text": "PE: Peru",
-                  "index": 59
+                  "index": 173
+                },
+                "PF": {
+                  "text": "PF: French Polynesia",
+                  "index": 174
+                },
+                "PG": {
+                  "text": "PG: Papua New Guinea",
+                  "index": 175
+                },
+                "PH": {
+                  "text": "PH: Philippines",
+                  "index": 176
+                },
+                "PK": {
+                  "text": "PK: Pakistan",
+                  "index": 177
+                },
+                "PL": {
+                  "text": "PL: Poland",
+                  "index": 178
+                },
+                "PM": {
+                  "text": "PM: Saint Pierre and Miquelon",
+                  "index": 179
+                },
+                "PN": {
+                  "text": "PN: Pitcairn",
+                  "index": 180
+                },
+                "PR": {
+                  "text": "PR: Puerto Rico",
+                  "index": 181
+                },
+                "PS": {
+                  "text": "PS: Palestine, State of",
+                  "index": 182
+                },
+                "PT": {
+                  "text": "PT: Portugal",
+                  "index": 183
+                },
+                "PW": {
+                  "text": "PW: Palau",
+                  "index": 184
+                },
+                "PY": {
+                  "text": "PY: Paraguay",
+                  "index": 185
+                },
+                "QA": {
+                  "text": "QA: Qatar",
+                  "index": 186
+                },
+                "RE": {
+                  "text": "RE: R\u00e9union",
+                  "index": 187
+                },
+                "RO": {
+                  "text": "RO: Romania",
+                  "index": 188
+                },
+                "RS": {
+                  "text": "RS: Serbia",
+                  "index": 189
+                },
+                "RU": {
+                  "text": "RU: Russian Federation",
+                  "index": 190
+                },
+                "RW": {
+                  "text": "RW: Rwanda",
+                  "index": 191
+                },
+                "SA": {
+                  "text": "SA: Saudi Arabia",
+                  "index": 192
+                },
+                "SB": {
+                  "text": "SB: Solomon Islands",
+                  "index": 193
+                },
+                "SC": {
+                  "text": "SC: Seychelles",
+                  "index": 194
+                },
+                "SD": {
+                  "text": "SD: Sudan",
+                  "index": 195
+                },
+                "SE": {
+                  "text": "SE: Sweden",
+                  "index": 196
                 },
                 "SG": {
                   "text": "SG: Singapore",
-                  "index": 60
+                  "index": 197
+                },
+                "SH": {
+                  "text": "SH: Saint Helena, Ascension and Tristan da Cunha",
+                  "index": 198
+                },
+                "SI": {
+                  "text": "SI: Slovenia",
+                  "index": 199
+                },
+                "SJ": {
+                  "text": "SJ: Svalbard and Jan Mayen",
+                  "index": 200
+                },
+                "SK": {
+                  "text": "SK: Slovakia",
+                  "index": 201
+                },
+                "SL": {
+                  "text": "SL: Sierra Leone",
+                  "index": 202
+                },
+                "SM": {
+                  "text": "SM: San Marino",
+                  "index": 203
+                },
+                "SN": {
+                  "text": "SN: Senegal",
+                  "index": 204
+                },
+                "SO": {
+                  "text": "SO: Somalia",
+                  "index": 205
+                },
+                "SR": {
+                  "text": "SR: Suriname",
+                  "index": 206
+                },
+                "SS": {
+                  "text": "SS: South Sudan",
+                  "index": 207
+                },
+                "ST": {
+                  "text": "ST: Sao Tome and Principe",
+                  "index": 208
+                },
+                "SV": {
+                  "text": "SV: El Salvador",
+                  "index": 209
+                },
+                "SX": {
+                  "text": "SX: Sint Maarten (Dutch part)",
+                  "index": 210
+                },
+                "SY": {
+                  "text": "SY: Syrian Arab Republic",
+                  "index": 211
+                },
+                "SZ": {
+                  "text": "SZ: Eswatini",
+                  "index": 212
+                },
+                "TC": {
+                  "text": "TC: Turks and Caicos Islands",
+                  "index": 213
+                },
+                "TD": {
+                  "text": "TD: Chad",
+                  "index": 214
+                },
+                "TF": {
+                  "text": "TF: French Southern Territories",
+                  "index": 215
+                },
+                "TG": {
+                  "text": "TG: Togo",
+                  "index": 216
+                },
+                "TH": {
+                  "text": "TH: Thailand",
+                  "index": 217
+                },
+                "TJ": {
+                  "text": "TJ: Tajikistan",
+                  "index": 218
+                },
+                "TK": {
+                  "text": "TK: Tokelau",
+                  "index": 219
+                },
+                "TL": {
+                  "text": "TL: Timor-Leste",
+                  "index": 220
+                },
+                "TM": {
+                  "text": "TM: Turkmenistan",
+                  "index": 221
                 },
                 "TN": {
                   "text": "TN: Tunisia",
-                  "index": 61
+                  "index": 222
+                },
+                "TO": {
+                  "text": "TO: Tonga",
+                  "index": 223
+                },
+                "TR": {
+                  "text": "TR: T\u00fcrkiye",
+                  "index": 224
+                },
+                "TT": {
+                  "text": "TT: Trinidad and Tobago",
+                  "index": 225
+                },
+                "TV": {
+                  "text": "TV: Tuvalu",
+                  "index": 226
+                },
+                "TW": {
+                  "text": "TW: Taiwan, Province of China",
+                  "index": 227
+                },
+                "TZ": {
+                  "text": "TZ: Tanzania, United Republic of",
+                  "index": 228
+                },
+                "UA": {
+                  "text": "UA: Ukraine",
+                  "index": 229
+                },
+                "UG": {
+                  "text": "UG: Uganda",
+                  "index": 230
+                },
+                "UM": {
+                  "text": "UM: United States Minor Outlying Islands",
+                  "index": 231
+                },
+                "US": {
+                  "text": "US: United States",
+                  "index": 232
+                },
+                "UY": {
+                  "text": "UY: Uruguay",
+                  "index": 233
                 },
                 "UZ": {
                   "text": "UZ: Uzbekistan",
-                  "index": 62
+                  "index": 234
+                },
+                "VA": {
+                  "text": "VA: Holy See (Vatican City State)",
+                  "index": 235
+                },
+                "VC": {
+                  "text": "VC: Saint Vincent and the Grenadines",
+                  "index": 236
+                },
+                "VE": {
+                  "text": "VE: Venezuela, Bolivarian Republic of",
+                  "index": 237
+                },
+                "VG": {
+                  "text": "VG: Virgin Islands, British",
+                  "index": 238
+                },
+                "VI": {
+                  "text": "VI: Virgin Islands, U.S.",
+                  "index": 239
+                },
+                "VN": {
+                  "text": "VN: Viet Nam",
+                  "index": 240
+                },
+                "VU": {
+                  "text": "VU: Vanuatu",
+                  "index": 241
+                },
+                "WF": {
+                  "text": "WF: Wallis and Futuna",
+                  "index": 242
+                },
+                "WS": {
+                  "text": "WS: Samoa",
+                  "index": 243
+                },
+                "YE": {
+                  "text": "YE: Yemen",
+                  "index": 244
+                },
+                "YT": {
+                  "text": "YT: Mayotte",
+                  "index": 245
+                },
+                "ZA": {
+                  "text": "ZA: South Africa",
+                  "index": 246
+                },
+                "ZM": {
+                  "text": "ZM: Zambia",
+                  "index": 247
+                },
+                "ZW": {
+                  "text": "ZW: Zimbabwe",
+                  "index": 248
                 }
               }
             }

--- a/configs/monitoring/grafana/provisioning/dashboards/conduit.json
+++ b/configs/monitoring/grafana/provisioning/dashboards/conduit.json
@@ -1066,6 +1066,38 @@
                 "ZW": {
                   "text": "ZW: Zimbabwe",
                   "index": 54
+                },
+                "AZ": {
+                  "text": "AZ: Azerbaijan",
+                  "index": 55
+                },
+                "GT": {
+                  "text": "GT: Guatemala",
+                  "index": 56
+                },
+                "KE": {
+                  "text": "KE: Kenya",
+                  "index": 57
+                },
+                "LT": {
+                  "text": "LT: Lithuania",
+                  "index": 58
+                },
+                "PE": {
+                  "text": "PE: Peru",
+                  "index": 59
+                },
+                "SG": {
+                  "text": "SG: Singapore",
+                  "index": 60
+                },
+                "TN": {
+                  "text": "TN: Tunisia",
+                  "index": 61
+                },
+                "UZ": {
+                  "text": "UZ: Uzbekistan",
+                  "index": 62
                 }
               }
             }
@@ -1740,6 +1772,102 @@
                 "value": "ZW: Zimbabwe"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AZ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AZ: Azerbaijan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GT"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GT: Guatemala"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "KE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KE: Kenya"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "LT"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "LT: Lithuania"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PE: Peru"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SG: Singapore"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TN"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TN: Tunisia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "UZ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "UZ: Uzbekistan"
+              }
+            ]
           }
         ]
       },
@@ -2016,6 +2144,38 @@
                 "ZW": {
                   "text": "ZW: Zimbabwe",
                   "index": 54
+                },
+                "AZ": {
+                  "text": "AZ: Azerbaijan",
+                  "index": 55
+                },
+                "GT": {
+                  "text": "GT: Guatemala",
+                  "index": 56
+                },
+                "KE": {
+                  "text": "KE: Kenya",
+                  "index": 57
+                },
+                "LT": {
+                  "text": "LT: Lithuania",
+                  "index": 58
+                },
+                "PE": {
+                  "text": "PE: Peru",
+                  "index": 59
+                },
+                "SG": {
+                  "text": "SG: Singapore",
+                  "index": 60
+                },
+                "TN": {
+                  "text": "TN: Tunisia",
+                  "index": 61
+                },
+                "UZ": {
+                  "text": "UZ: Uzbekistan",
+                  "index": 62
                 }
               }
             }
@@ -2433,6 +2593,38 @@
                 "ZW": {
                   "text": "ZW: Zimbabwe",
                   "index": 54
+                },
+                "AZ": {
+                  "text": "AZ: Azerbaijan",
+                  "index": 55
+                },
+                "GT": {
+                  "text": "GT: Guatemala",
+                  "index": 56
+                },
+                "KE": {
+                  "text": "KE: Kenya",
+                  "index": 57
+                },
+                "LT": {
+                  "text": "LT: Lithuania",
+                  "index": 58
+                },
+                "PE": {
+                  "text": "PE: Peru",
+                  "index": 59
+                },
+                "SG": {
+                  "text": "SG: Singapore",
+                  "index": 60
+                },
+                "TN": {
+                  "text": "TN: Tunisia",
+                  "index": 61
+                },
+                "UZ": {
+                  "text": "UZ: Uzbekistan",
+                  "index": 62
                 }
               }
             }


### PR DESCRIPTION
## Summary

Improvements to the Conduit Grafana dashboard, made by [@jSFBay](https://github.com/jSFBay) with assistance from [Claude Code](https://claude.ai/claude-code) (Anthropic).

Original dashboard credit: [@shayanb](https://github.com/shayanb) — these changes build on your excellent work.

## Changes

- **Country names**: Both region panels now display `CODE: Country Name` (e.g. `MM: Myanmar`) instead of 2-letter ISO codes — much easier to read at a glance
- **55 country mappings** covering all regions currently served by Psiphon Conduit
- **Split region panel**: The *Connected Clients by Region* panel is now two separate panels — one for the graph, one for the stats table (Mean, Max, Last) — so each can be independently resized in the dashboard
- **Stats panel** sorted by Last value descending for quick visibility of most active regions

## Notes

All changes are backwards compatible — if new region codes appear that are not yet mapped, they will simply display as their 2-letter code as before.