### PR TITLE
docs(fa): sync README-fa.md with v1.8.2 (badge + Changelog)

### DIFF
--- a/README-fa.md
+++ b/README-fa.md
@@ -2,6 +2,8 @@
 
 # MoaV
 
+[![Website](https://img.shields.io/badge/website-moav.sh-cyan.svg)](https://moav.sh)  [![Docs](https://img.shields.io/badge/docs-moav.sh%2Fdocs-cyan.svg)](https://moav.sh/docs/)  [![Version](https://img.shields.io/badge/version-1.8.2-blue.svg)](CHANGELOG.md)  [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+
 **[English](README.md)** | فارسی
 
 استک عبور از سانسور چند پروتکلی بهینه‌سازی شده برای محیط‌های شبکه‌ای خصمانه.
@@ -360,6 +362,10 @@ MoaV/
 ## مجوز
 
 MIT
+
+## تغییرات
+
+برای یادداشت‌های انتشار و تاریخچه نسخه‌ها به [CHANGELOG.md](CHANGELOG.md) مراجعه کنید.
 
 ## سلب مسئولیت
 


### PR DESCRIPTION
Mechanical FA-README sync. The English README ships a version-badge row at the top and a top-level Changelog section near the bottom; the FA mirror was missing both since at least v1.7.x.

## Changes

- **Badge row** added under \`# MoaV\`: Website / Docs / Version (1.8.2) / License — same shields, same URLs.
- **\`## تغییرات\`** (Changelog) section added before Disclaimer, linking to \`CHANGELOG.md\`.

## Why now

Surfaced by a v1.8.2 docs audit. The 1.8.x feature mentions in the FA README (Shadowsocks-2022 default-on, MasterDNS, XDNS, all-4-DNS-tunnels-on-port-53 framing) were already current from earlier release sweeps — no content drift in the body. Only the badge and Changelog were structurally missing.

## Scope

Two files touched (just README-fa.md); ~3 lines added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)