### PR TITLE
docs: refresh for v1.8.2 + new architecture page + llms.txt

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -232,15 +232,29 @@ Start services.
 
 ```bash
 moav start                    # Start DEFAULT_PROFILES from .env
-moav start all                # Start all services
+moav start all                # Start all services whose ENABLE_* is true
 moav start proxy              # Start proxy profile only
 moav start proxy admin        # Start multiple profiles
 moav start proxy wireguard admin  # Start three profiles
 ```
 
 **Arguments:**
-- No arguments: Uses `DEFAULT_PROFILES` from `.env`
-- Profile names: Start specific profiles (space-separated)
+- No arguments: uses `DEFAULT_PROFILES` from `.env`
+- Profile names: start specific profiles (space-separated)
+- `--force` / `-f`: bypass the profile-filtering prompt (see below)
+
+##### Profile filtering (1.8.2+)
+
+`DEFAULT_PROFILES` and `--profile all` are docker-compose constructs that don't know about MoaV's `ENABLE_*` flags. `moav start` bridges that:
+
+- **No-args** (reads `DEFAULT_PROFILES`): silently drops profiles whose `ENABLE_*` is `false` in `.env`. Prints one line — `Skipping disabled profiles: <list>` — when anything is filtered, so stale entries self-heal on the next start.
+- **`moav start all`**: expands `all` to the set of profiles whose `ENABLE_*` is true, instead of starting every Compose profile member. Build / logs / down ops still treat `--profile all` as everything.
+- **`moav start <name>` for a disabled profile**: prompts with three options:
+  1. **Enable + start** — sets `ENABLE_*=true` in `.env`, then starts (persists for next time).
+  2. **Skip** — don't start; `.env` stays as-is.
+  3. **Start once** — start now without modifying `.env` (won't auto-start next time).
+
+  Multi-flag profiles (`proxy`, `dnstunnel`) can't be auto-flipped — option 1 shows which underlying flags to set. Non-interactive shells default to skip. `--force` bypasses the prompt.
 
 #### `moav stop`
 Stop services.
@@ -567,6 +581,19 @@ link inside Ryve.
 > publicly. The link you share with users is the Personal Pairing link
 > generated inside Ryve, not the claim link. `moav donate info` is an alias.
 
+#### `moav conduit-offsets`
+Manage the Conduit lifetime-bandwidth offset auto-updater (1.7.9+).
+
+Conduit's `conduit_bytes_downloaded` / `conduit_bytes_uploaded` gauges reset on every container restart, so cumulative donation totals would be lost without intervention. MoaV banks each pre-restart total into a persistent offset that Prometheus adds back via recording rules; a systemd unit watches Conduit `start` events and runs the updater automatically.
+
+```bash
+moav conduit-offsets install    # Install the systemd watcher (default on first start)
+moav conduit-offsets status     # Show watcher state (enabled/disabled, last run)
+moav conduit-offsets uninstall  # Remove the watcher
+```
+
+`moav start` auto-installs the watcher the first time Conduit + monitoring run together (set `CONDUIT_OFFSETS_AUTOUPDATE=false` in `.env` to opt out). Hosts without systemd are skipped silently; run `scripts/update-conduit-offsets.sh` manually after each Conduit restart, or from cron. See [Monitoring → Conduit lifetime bandwidth](MONITORING.md#conduit-lifetime-bandwidth).
+
 ---
 
 ### Migration
@@ -632,26 +659,30 @@ Use this after:
 
 ## Profiles
 
-Profiles group related services together.
+Profiles group related services. Each maps to one or more `ENABLE_*` flags in `.env`; `moav start` filters disabled profiles automatically (see [Profile filtering](#moav-start)).
 
-| Profile | Services Included |
-|---------|-------------------|
-| `proxy` | sing-box, decoy, certbot |
-| `wireguard` | wireguard, wstunnel |
-| `dnstt` | dnstt |
-| `slipstream` | slipstream |
-| `masterdns` | masterdns |
-| `trusttunnel` | trusttunnel |
-| `admin` | admin |
-| `conduit` | psiphon-conduit |
-| `snowflake` | snowflake |
-| `client` | client (for testing) |
-| `all` | All of the above |
+| Profile | Services | Controlled by |
+|---------|----------|---------------|
+| `proxy` | sing-box, decoy, certbot | `ENABLE_REALITY` / `ENABLE_TROJAN` / `ENABLE_HYSTERIA2` / `ENABLE_SS` (any) |
+| `xhttp` | xray | `ENABLE_XHTTP` |
+| `wireguard` | wireguard, wstunnel, decoy, certbot | `ENABLE_WIREGUARD` |
+| `amneziawg` | amneziawg | `ENABLE_AMNEZIAWG` |
+| `dnstunnel` | dns-router, dnstt, slipstream, masterdns, xray (XDNS) | `ENABLE_DNSTT` / `ENABLE_SLIPSTREAM` / `ENABLE_MASTERDNS` / `ENABLE_XDNS` (any) |
+| `trusttunnel` | trusttunnel | `ENABLE_TRUSTTUNNEL` |
+| `telegram` | telemt | `ENABLE_TELEMT` |
+| `admin` | admin, docker-proxy | `ENABLE_ADMIN_UI` |
+| `conduit` | psiphon-conduit | `ENABLE_CONDUIT` |
+| `snowflake` | snowflake, snowflake-exporter | `ENABLE_SNOWFLAKE` |
+| `gooserelay` | gooserelay | `ENABLE_GOOSERELAY` (opt-in) |
+| `monitoring` | prometheus, grafana, grafana-proxy, node-exporter, cadvisor + per-protocol exporters | `ENABLE_MONITORING` (opt-in) |
+| `setup` | bootstrap, geoip-updater | (lifecycle, not user-toggled) |
+| `client` | client | (for local testing) |
+| `all` | All services above | (used by `moav start all`, `moav build`, `moav logs`, etc.) |
 
 **Usage:**
 ```bash
 moav start proxy admin        # Start proxy and admin profiles
-moav start all                # Start everything
+moav start all                # Expands to every profile whose ENABLE_* is true
 ```
 
 ---

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -243,18 +243,17 @@ moav start proxy wireguard admin  # Start three profiles
 - Profile names: start specific profiles (space-separated)
 - `--force` / `-f`: bypass the profile-filtering prompt (see below)
 
-##### Profile filtering (1.8.2+)
+##### Disabled profiles
 
-`DEFAULT_PROFILES` and `--profile all` are docker-compose constructs that don't know about MoaV's `ENABLE_*` flags. `moav start` bridges that:
+`moav start` respects the `ENABLE_*` flags in `.env`:
 
-- **No-args** (reads `DEFAULT_PROFILES`): silently drops profiles whose `ENABLE_*` is `false` in `.env`. Prints one line — `Skipping disabled profiles: <list>` — when anything is filtered, so stale entries self-heal on the next start.
-- **`moav start all`**: expands `all` to the set of profiles whose `ENABLE_*` is true, instead of starting every Compose profile member. Build / logs / down ops still treat `--profile all` as everything.
-- **`moav start <name>` for a disabled profile**: prompts with three options:
-  1. **Enable + start** — sets `ENABLE_*=true` in `.env`, then starts (persists for next time).
+- **No args** or **`moav start all`**: starts only the profiles whose `ENABLE_*` is `true`. Anything disabled is skipped (you'll see `Skipping disabled profiles: <list>`).
+- **`moav start <name>`** for a profile that's disabled in `.env`: you get a prompt:
+  1. **Enable + start** — flips `ENABLE_*=true` in `.env`, then starts (persists for next time).
   2. **Skip** — don't start; `.env` stays as-is.
   3. **Start once** — start now without modifying `.env` (won't auto-start next time).
 
-  Multi-flag profiles (`proxy`, `dnstunnel`) can't be auto-flipped — option 1 shows which underlying flags to set. Non-interactive shells default to skip. `--force` bypasses the prompt.
+  For profiles backed by multiple flags (`proxy`, `dnstunnel`), option 1 shows which flags to set manually. `--force` bypasses the prompt. Non-interactive shells default to skip.
 
 #### `moav stop`
 Stop services.
@@ -582,17 +581,15 @@ link inside Ryve.
 > generated inside Ryve, not the claim link. `moav donate info` is an alias.
 
 #### `moav conduit-offsets`
-Manage the Conduit lifetime-bandwidth offset auto-updater (1.7.9+).
-
-Conduit's `conduit_bytes_downloaded` / `conduit_bytes_uploaded` gauges reset on every container restart, so cumulative donation totals would be lost without intervention. MoaV banks each pre-restart total into a persistent offset that Prometheus adds back via recording rules; a systemd unit watches Conduit `start` events and runs the updater automatically.
+Manage the watcher that keeps Conduit's **lifetime bandwidth** Grafana panels accurate across container restarts.
 
 ```bash
-moav conduit-offsets install    # Install the systemd watcher (default on first start)
+moav conduit-offsets install    # Install the systemd watcher
 moav conduit-offsets status     # Show watcher state (enabled/disabled, last run)
 moav conduit-offsets uninstall  # Remove the watcher
 ```
 
-`moav start` auto-installs the watcher the first time Conduit + monitoring run together (set `CONDUIT_OFFSETS_AUTOUPDATE=false` in `.env` to opt out). Hosts without systemd are skipped silently; run `scripts/update-conduit-offsets.sh` manually after each Conduit restart, or from cron. See [Monitoring → Conduit lifetime bandwidth](MONITORING.md#conduit-lifetime-bandwidth).
+The watcher installs itself automatically the first time Conduit and monitoring run together — you usually don't need to touch this. Set `CONDUIT_OFFSETS_AUTOUPDATE=false` in `.env` to opt out. Hosts without systemd skip the watcher; run `scripts/update-conduit-offsets.sh` from cron instead. See [Monitoring → Conduit lifetime bandwidth](MONITORING.md#conduit-lifetime-bandwidth).
 
 ---
 

--- a/docs/DNS.md
+++ b/docs/DNS.md
@@ -232,42 +232,40 @@ TTL: 300
 >
 > All other records **must** be DNS only (gray cloud).
 
-#### CDN Origin Rule (Required for CDN Mode)
+#### CDN settings (required for CDN Mode)
 
-If you added the `cdn` record above, you **must** also create an Origin Rule to redirect traffic to port 2082. By default, Cloudflare's Flexible SSL connects to origin port 80, but MoaV's CDN listener runs on port 2082.
+If you added the `cdn` record above, CDN mode needs **two** Cloudflare settings — both are required, neither is optional:
 
-**Step 1: Go to Rules → Origin Rules**
+**1. Origin Rule** — rewrites Cloudflare → origin port to 2082, because MoaV's CDN listener doesn't bind 80 or 443.
 
-1. In Cloudflare Dashboard, select your domain
-2. Navigate to **Rules** → **Origin Rules**
-3. Click **Create rule**
-
-**Step 2: Configure the Rule**
+In Cloudflare Dashboard → **Rules → Origin Rules → Create rule**:
 
 | Field | Value |
 |-------|-------|
 | Rule name | `CDN to port 2082` |
-| When incoming requests match... | **Hostname** equals `cdn.yourdomain.com` |
-| Then... | **Destination Port** → Rewrite to `2082` |
+| When incoming requests match… | **Hostname** equals `cdn.yourdomain.com` |
+| Then… | **Destination Port** → Rewrite to `2082` |
 
-**Step 3: Deploy**
+Click **Deploy**.
 
-Click **Deploy** to activate the rule.
+**2. SSL/TLS encryption mode** — set to **Flexible**, because MoaV's CDN inbound on 2082 is plain HTTP (Cloudflare terminates TLS for the client).
 
-**Verify it works:**
+In Cloudflare Dashboard → **SSL/TLS → Overview**: choose **Flexible**.
+
+If you need Full / Full (Strict) for *other* subdomains, leave the global setting alone and add a **Configuration Rule** scoped to `cdn.yourdomain.com` only with SSL/TLS mode = Flexible.
+
+**Verify both are working:**
 ```bash
-# Should return HTTP 400 (sing-box responding, not Cloudflare 521)
-# Use any path - the CDN WS path is auto-generated during bootstrap
-curl -s -o /dev/null -w "%{http_code}" https://cdn.yourdomain.com/test
+curl -s -o /dev/null -w "%{http_code}" https://cdn.yourdomain.com/anything
 ```
 
-A `400` or `404` response means sing-box is receiving the request.
-- `521` = Origin Rule is missing or misconfigured
-- `525` = SSL mode is wrong — set Cloudflare SSL/TLS to **Flexible** (not Full/Strict), because MoaV's CDN port 2082 is plain HTTP
+| Response | Meaning |
+|---|---|
+| `400` or `404` | sing-box is responding — CDN is working |
+| `521` | Origin Rule is missing — Cloudflare can't reach origin port 2082 |
+| `525` | SSL mode is wrong — set Cloudflare SSL/TLS to Flexible |
 
-> **Important:** Cloudflare SSL/TLS mode must be set to **Flexible** for CDN mode. MoaV's CDN inbound on port 2082 is plain HTTP (Cloudflare terminates TLS). If you need Full SSL for other subdomains, use a Configuration Rule to set Flexible for just `cdn.yourdomain.com`.
-
-See [CDN Setup Guide](SETUP.md#cdn-fronted-vlesswebsocket-cloudflare) for complete CDN configuration.
+See [CDN Setup Guide](SETUP.md#cdn-fronted-vlesswebsocket-cloudflare) for end-to-end configuration.
 
 ### AWS CloudFront (Alternative CDN)
 

--- a/docs/DNS.md
+++ b/docs/DNS.md
@@ -131,57 +131,29 @@ TTL: 300
 
 This creates `dns.yourdomain.com` pointing to your server (used as the nameserver for tunnel subdomains).
 
-#### Step 3: NS Delegation for dnstt
+#### Steps 3–6: NS Delegations for the four DNS tunnels
+
+All four tunnels — **dnstt** (`t.`), **Slipstream** (`s.`), **MasterDNS** (`m.`), and **XDNS** (`x.`) — are enabled by default and share port 53 via `dns-router`, which fans queries out by subdomain. Each needs its own NS delegation:
+
+| Tunnel | Subdomain | `ENABLE_*` |
+|--------|-----------|------------|
+| **dnstt** — KCP+Noise, broadest client support | `t.` | `ENABLE_DNSTT` |
+| **Slipstream** — QUIC-over-DNS, 1.5–5× faster than dnstt | `s.` | `ENABLE_SLIPSTREAM` |
+| **MasterDNS** — ARQ + resolver load-balancing, bundled in MahsaNG v16 | `m.` | `ENABLE_MASTERDNS` |
+| **XDNS** — Xray FinalMask mKCP, per-user auth (needs FinalMask client: Happ, Xray CLI) | `x.` | `ENABLE_XDNS` |
+
+Add one NS record per tunnel you want to expose, all pointing at the same nameserver host:
 
 ```
 Type: NS
-Name: t
+Name: t        # or s / m / x (one record per tunnel)
 Value: dns.yourdomain.com
 TTL: 300
 ```
 
-This tells DNS resolvers that queries for `*.t.yourdomain.com` should be sent to `dns.yourdomain.com` (your server). Used by dnstt.
+The container for any disabled tunnel stays down — `dns-router` just doesn't route to it. To opt a tunnel out, set its `ENABLE_*` to `false` in `.env`.
 
-#### Step 4: NS Delegation for Slipstream
-
-```
-Type: NS
-Name: s
-Value: dns.yourdomain.com
-TTL: 300
-```
-
-Same concept as dnstt, but for the Slipstream QUIC-over-DNS tunnel. Slipstream is 1.5-5x faster than dnstt. Enabled by default (`ENABLE_SLIPSTREAM=true`); set `false` to opt out.
-
-#### Step 5: NS Delegation for XDNS (Recommended)
-
-```
-Type: NS
-Name: x
-Value: dns.yourdomain.com
-TTL: 300
-```
-
-XDNS is a DNS tunnel protocol that uses Xray-core's FinalMask technology to encode VLESS traffic in DNS-like packets via mKCP transport, with per-user authentication. It requires a FinalMask-aware client (Happ, Xray CLI). Enabled by default (`ENABLE_XDNS=true`); set `false` to opt out.
-
-> **Note**: All four DNS tunnels — dnstt, Slipstream, MasterDNS, and XDNS — share port 53 simultaneously via `dns-router`, which fans queries out by subdomain suffix (`t.` → dnstt, `s.` → Slipstream, `m.` → MasterDNS, `x.` → XDNS). No `moav switch-dns` is needed; all four are **enabled by default**. XDNS requires a FinalMask-aware client (Happ, Xray CLI) — the container runs regardless, but only those clients can use it. Set `ENABLE_XDNS=false` to opt out.
-
-> **Client-side resolver choice**: All four DNS tunnels rely on a public DNS resolver the *client* can reach — `1.1.1.1` and `8.8.8.8` are commonly throttled or null-routed during shutdowns. XDNS round-robins across multiple resolvers via `XDNS_RESOLVERS` in `.env`; dnstt and Slipstream take a `--dns-server` / `-doh` flag at the client. See [protocols.md → Reachable DNS resolvers](protocols.md#reachable-dns-resolvers) for resolver-scanning guidance ([findns](https://github.com/SamNet-dev/findns), [dns-mns](https://gitlab.com/E-Gurl/dns-mns)).
-
-#### Step 6: NS Delegation for MasterDNS
-
-```
-Type: NS
-Name: m
-Value: dns.yourdomain.com
-TTL: 300
-```
-
-Same concept as dnstt, for the MasterDNS advanced DNS tunnel (the DNS tunnel
-bundled in MahsaNG v16). Enabled by default (`ENABLE_MASTERDNS=true`; set to
-`false` to opt out). MasterDNS shares port 53 *with* dnstt/Slipstream —
-`dns-router` fans queries out by subdomain (`m` → MasterDNS, `t` → dnstt,
-`s` → Slipstream), so no `switch-dns` is required to run all three together.
+> **Client-side resolver choice**: All four tunnels rely on a public DNS resolver the *client* can reach. `1.1.1.1` / `8.8.8.8` are commonly throttled or null-routed during shutdowns. XDNS round-robins across multiple resolvers via `XDNS_RESOLVERS` in `.env`; dnstt and Slipstream take a `--dns-server` / `-doh` flag at the client. See [protocols.md → Reachable DNS resolvers](protocols.md#reachable-dns-resolvers) for resolver-scanning ([findns](https://github.com/SamNet-dev/findns), [dns-mns](https://gitlab.com/E-Gurl/dns-mns)).
 
 #### Which DNS tunnel should I use?
 
@@ -247,6 +219,8 @@ TTL: 300
 | A | dns | YOUR_IP | DNS only |
 | NS | t | dns.yourdomain.com | — |
 | NS | s | dns.yourdomain.com | — |
+| NS | m | dns.yourdomain.com | — |
+| NS | x | dns.yourdomain.com | — |
 | A | cdn | YOUR_IP | **Proxied** (orange cloud) |
 | A | www | YOUR_IP | **Proxied** (orange cloud) |
 | A | grafana | YOUR_IP | **Proxied** (orange cloud) |

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -100,7 +100,7 @@ Tor donation metrics from Snowflake Exporter:
 - Connections over time
 - Bandwidth over time
 
-> The Snowflake exporter follows the relay (1.8.2: profile membership moved from `[monitoring, all]` to `[snowflake, all]`). When `ENABLE_SNOWFLAKE=false` the exporter stays off too, so the Snowflake panels won't emit stale data.
+> The Snowflake exporter only runs when the Snowflake relay does. With `ENABLE_SNOWFLAKE=false`, no Snowflake panels emit data.
 
 ### MoaV - Conduit
 
@@ -112,12 +112,9 @@ Psiphon donation metrics:
 
 ## Conduit lifetime bandwidth
 
-The lifetime gauges depend on two pieces that ship together (1.7.9+):
+Conduit's live bandwidth gauges reset every time the container restarts. The **Lifetime Download / Lifetime Upload** panels work around that by adding a persistent offset back — so your cumulative donation totals keep growing across restarts.
 
-1. **Recording rules** at `configs/monitoring/conduit_lifetime.rules.yml` — materialized from `conduit_lifetime.rules.yml.template` on first monitoring start (the live file is gitignored because it holds per-install offsets).
-2. **Offset auto-updater** (`scripts/update-conduit-offsets.sh`) — banks the running total into the offset just before a Conduit restart wipes the live gauges, then SIGHUPs Prometheus to reload the rule.
-
-A **systemd watcher** (`moav-conduit-offsets.service`) reacts to Conduit `start` events and runs the updater automatically with a settle delay. `moav start` auto-installs the watcher the first time Conduit + monitoring run together — opt out with `CONDUIT_OFFSETS_AUTOUPDATE=false`. Manage directly with [`moav conduit-offsets {install|uninstall|status}`](CLI.md#moav-conduit-offsets). Hosts without systemd skip the watcher silently; run the updater from cron or by hand after each Conduit restart instead.
+This is automatic once monitoring and Conduit are both running. A systemd watcher banks the pre-restart total and reloads Prometheus the moment Conduit comes back up. Manage it with [`moav conduit-offsets`](CLI.md#moav-conduit-offsets); set `CONDUIT_OFFSETS_AUTOUPDATE=false` in `.env` to opt out. Hosts without systemd can run `scripts/update-conduit-offsets.sh` from cron.
 
 ## GeoIP Country Distribution
 

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -100,6 +100,25 @@ Tor donation metrics from Snowflake Exporter:
 - Connections over time
 - Bandwidth over time
 
+> The Snowflake exporter follows the relay (1.8.2: profile membership moved from `[monitoring, all]` to `[snowflake, all]`). When `ENABLE_SNOWFLAKE=false` the exporter stays off too, so the Snowflake panels won't emit stale data.
+
+### MoaV - Conduit
+
+Psiphon donation metrics:
+
+- **Live bandwidth** (`conduit_bytes_downloaded` / `conduit_bytes_uploaded`) — in-memory gauges, reset on every Conduit container restart.
+- **Lifetime bandwidth** (`conduit_bytes_downloaded_lifetime` / `conduit_bytes_uploaded_lifetime`) — Prometheus recording rule that adds a per-install offset to the live counters, so cumulative donation totals survive restarts.
+- **Connected clients** + per-region splits.
+
+## Conduit lifetime bandwidth
+
+The lifetime gauges depend on two pieces that ship together (1.7.9+):
+
+1. **Recording rules** at `configs/monitoring/conduit_lifetime.rules.yml` — materialized from `conduit_lifetime.rules.yml.template` on first monitoring start (the live file is gitignored because it holds per-install offsets).
+2. **Offset auto-updater** (`scripts/update-conduit-offsets.sh`) — banks the running total into the offset just before a Conduit restart wipes the live gauges, then SIGHUPs Prometheus to reload the rule.
+
+A **systemd watcher** (`moav-conduit-offsets.service`) reacts to Conduit `start` events and runs the updater automatically with a settle delay. `moav start` auto-installs the watcher the first time Conduit + monitoring run together — opt out with `CONDUIT_OFFSETS_AUTOUPDATE=false`. Manage directly with [`moav conduit-offsets {install|uninstall|status}`](CLI.md#moav-conduit-offsets). Hosts without systemd skip the watcher silently; run the updater from cron or by hand after each Conduit restart instead.
+
 ## GeoIP Country Distribution
 
 All four protocol dashboards (sing-box, Xray, WireGuard, AmneziaWG) include a "Geographic Distribution" row showing user connections by country.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -231,6 +231,8 @@ This will:
 4. Create initial users (default: 5)
 5. Generate user bundles with configs and QR codes
 
+> **1.8.2 — interactive bootstrap niceties:** if you paste `https://your-domain.com/` as the domain, the prompt strips the scheme/slash and shows `Cleaned input: 'https://your-domain.com/' → 'your-domain.com'`. Arrow keys edit the line (readline enabled). If you Ctrl-C after typing the domain but before the email, the next `moav bootstrap` notices `DOMAIN` is set but `ACME_EMAIL` isn't, re-prompts for just the email, and still calls `ensure_admin_password` so a missed admin password doesn't slip through.
+
 **DNS Tunnel Preparation** (optional):
 
 If you want to use the DNS tunnel, free port 53 first:
@@ -257,19 +259,7 @@ moav start proxy admin wireguard # Add WireGuard
 moav start all                   # Everything
 ```
 
-**Available Profiles:**
-- `proxy` - Reality, Trojan, Hysteria2, CDN, Shadowsocks-2022 (sing-box + decoy)
-- `wireguard` - WireGuard VPN + wstunnel
-- `amneziawg` - AmneziaWG (obfuscated WireGuard)
-- `dnstt` - DNS tunnel
-- `trusttunnel` - TrustTunnel VPN
-- `telegram` - Telegram MTProxy (fake-TLS)
-- `xhttp` - XHTTP (VLESS+XHTTP+Reality via Xray-core)
-- `admin` - Admin dashboard
-- `conduit` - Psiphon bandwidth donation
-- `snowflake` - Tor bandwidth donation
-- `monitoring` - Grafana + Prometheus observability
-- `all` - Everything
+See [CLI Reference → Profiles](CLI.md#profiles) for the full profile/service/`ENABLE_*` matrix. Common profiles: `proxy`, `xhttp`, `wireguard`, `amneziawg`, `dnstunnel`, `trusttunnel`, `telegram`, `admin`, `conduit`, `snowflake`, `gooserelay`, `monitoring`. From 1.8.2, `moav start` filters profiles whose `ENABLE_*` is `false` in `.env` — disabled services never start by accident.
 
 **Open Firewall Ports:**
 ```bash

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -231,7 +231,7 @@ This will:
 4. Create initial users (default: 5)
 5. Generate user bundles with configs and QR codes
 
-> **1.8.2 — interactive bootstrap niceties:** if you paste `https://your-domain.com/` as the domain, the prompt strips the scheme/slash and shows `Cleaned input: 'https://your-domain.com/' → 'your-domain.com'`. Arrow keys edit the line (readline enabled). If you Ctrl-C after typing the domain but before the email, the next `moav bootstrap` notices `DOMAIN` is set but `ACME_EMAIL` isn't, re-prompts for just the email, and still calls `ensure_admin_password` so a missed admin password doesn't slip through.
+> The domain prompt accepts your domain in any form (`example.com`, `https://example.com/`, `example.com:443` — all work). If you stop mid-way, re-running `moav bootstrap` picks up where you left off.
 
 **DNS Tunnel Preparation** (optional):
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,119 @@
+# Architecture
+
+How MoaV is wired together. For protocol-level details see [protocols.md](protocols.md); for CLI behavior see [CLI.md](CLI.md); for DNS-tunnel mechanics see [DNS.md](DNS.md).
+
+## Container topology
+
+Every protocol is one or more containers grouped into a docker-compose **profile**. `moav start` translates `ENABLE_*` flags in `.env` into the set of profiles to bring up (see [CLI → Profile filtering](CLI.md#moav-start)).
+
+```
+                      ┌─────────────┐
+                      │   .env      │   ENABLE_* flags
+                      └──────┬──────┘
+                             │
+                  ┌──────────▼──────────┐
+                  │ derive_enabled_     │  moav.sh
+                  │ profiles()          │
+                  └──────────┬──────────┘
+                             │
+        ┌────────────┬───────┼───────┬────────────┬─────────────┐
+        ▼            ▼       ▼       ▼            ▼             ▼
+   ┌────────┐  ┌─────────┐ ┌────┐ ┌─────────┐ ┌─────────┐ ┌──────────┐
+   │ proxy  │  │wireguard│ │xhttp│ │dnstunnel│ │trustnl. │ │ admin    │
+   │ (sing- │  │ + wstun.│ │xray │ │dns-rtr+ │ │trust    │ │ admin+   │
+   │  box)  │  │         │ │     │ │4 tunnels│ │tunnel   │ │ proxy    │
+   └────────┘  └─────────┘ └────┘ └─────────┘ └─────────┘ └──────────┘
+   Reality,    WG-over-WS  VLESS+ dnstt/Slip/ HTTP/2 +    FastAPI +
+   Trojan,                 Reality MasterDNS/ QUIC (TLS)  HTTP Basic
+   Hysteria2,              +XHTTP  XDNS                   auth
+   SS-2022,
+   CDN VLESS+WS
+```
+
+Other profiles: `amneziawg`, `telegram` (telemt), `conduit` (Psiphon), `snowflake` (Tor), `gooserelay` (SOCKS5 over Google Apps Script), `monitoring` (Prometheus + Grafana + exporters), `setup` (bootstrap + GeoIP updater), `client` (local testing).
+
+## DNS-router fan-out
+
+All four DNS tunnels share **port 53** via `dns-router`, a small Go service that fans queries out by subdomain suffix. Each tunnel listens on an internal port; only `dns-router` binds the public port.
+
+```
+                         Public 53/udp
+                              │
+                       ┌──────▼──────┐
+                       │ dns-router  │   subdomain-match routing
+                       └──┬──┬──┬──┬─┘
+            t.*           │  │  │  │       x.*
+        ┌──────────┐ s.*  │  │  │  │  m.*  ┌──────────┐
+        │  dnstt   ◄──────┘  │  │  └──────►│ masterdns│
+        │  :5353   │ ┌──────►│  │          │  :5355   │
+        └──────────┘ │       │  └────────► xray :5355
+                ┌────▼────┐  │              (XDNS via FinalMask)
+                │slipstrm │  └────────► (other tunnels can be added)
+                │ :5354   │
+                └─────────┘
+```
+
+Add a tunnel only by adding its NS record (`t.` / `s.` / `m.` / `x.`); see [DNS → NS Delegations](DNS.md#steps-36-ns-delegations-for-the-four-dns-tunnels). Disabling a tunnel via `ENABLE_*=false` removes its container; `dns-router` just doesn't route to it.
+
+## Bundle generation flow
+
+User credentials and per-protocol configs originate inside the `bootstrap` container, then get rendered into per-user bundles on the host. The split exists because container-side bundle generation can't see the host's `outputs/` mount layout.
+
+```
+   moav user add alice
+            │
+            ▼
+   ┌─────────────────────────────────────────────────────────┐
+   │ bootstrap container (sing-box-user-add.sh)              │
+   │   - generates UUID + per-protocol keys                  │
+   │   - writes state/users/alice/credentials.env (volume)   │
+   └────────────────────┬────────────────────────────────────┘
+                        │  HOST sees state/users/ via volume
+                        ▼
+   ┌─────────────────────────────────────────────────────────┐
+   │ host: generate-single-user.sh                           │
+   │   - reads credentials.env + .env                        │
+   │   - writes outputs/bundles/alice/{*.txt, *.json, *.png, │
+   │     subscription.txt, README.html, ...}                 │
+   └─────────────────────────────────────────────────────────┘
+```
+
+Bundles split into three groups:
+
+- **V2Ray-compatible** (Reality, Trojan, Hysteria2, SS-2022, CDN, XHTTP) — share-link `.txt`s, QR `.png`s, a single base64 `subscription.txt` importable by MahsaNG / v2rayNG / Hiddify / Streisand.
+- **L3 VPNs** (WireGuard, AmneziaWG, TrustTunnel) — `.conf` / `.toml` configs + QR.
+- **DNS tunnels** (dnstt, Slipstream, MasterDNS, XDNS) and **donations** (GooseRelay) — text instruction files + protocol-specific config blobs (`xdns-config.json`, `gooserelay-AppsScript.gs` + `gooserelay-client_config.json`, etc.).
+
+`README.html` is a bilingual (EN/FA) collapsible bundle viewer with embedded QR images and one-click subscription import.
+
+## Monitoring stack
+
+The `monitoring` profile is opt-in. When enabled it adds Prometheus + Grafana plus a per-protocol exporter set; each exporter is in the same profile as its target service, not in `monitoring` itself, so disabling a protocol disables its metrics.
+
+```
+     ┌─────────────┐
+     │  Prometheus │ ←── scrape ──┐
+     └──────┬──────┘              │
+            │                     │
+            │ recording rules     ├─────► clash-exporter  (sing-box Clash API)
+            │ (Conduit lifetime)  ├─────► singbox-exporter (log parser)
+            ▼                     ├─────► xray-exporter
+     ┌─────────────┐              ├─────► telemt-exporter (REST /v1/health)
+     │   Grafana   │              ├─────► wireguard-exporter
+     │  + dashbds  │              ├─────► amneziawg-exporter
+     └─────────────┘              ├─────► snowflake-exporter (Snowflake profile)
+            ▲                     ├─────► node-exporter (host)
+            │                     └─────► cAdvisor (containers)
+            │
+        Optional: grafana-proxy → Cloudflare CDN
+```
+
+Pre-built dashboards land in `configs/monitoring/grafana/dashboards/`. The Conduit lifetime panels depend on `conduit_lifetime.rules.yml` + the offset-watcher pair — see [Monitoring → Conduit lifetime bandwidth](MONITORING.md#conduit-lifetime-bandwidth).
+
+## See also
+
+- [Setup Guide](SETUP.md) — step-by-step deployment walkthrough
+- [DNS Configuration](DNS.md) — NS records, resolver-mode vs direct-mode XDNS, port 53
+- [CLI Reference](CLI.md) — every `moav` command, including the profile filtering UX
+- [Supported Protocols](protocols.md) — protocol-level cipher, port, and client-compat detail
+- [Monitoring](MONITORING.md) — dashboards, Conduit lifetime, GeoIP setup

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,56 +4,72 @@ How MoaV is wired together. For protocol-level details see [protocols.md](protoc
 
 ## Container topology
 
-Every protocol is one or more containers grouped into a docker-compose **profile**. `moav start` translates `ENABLE_*` flags in `.env` into the set of profiles to bring up (see [CLI → Profile filtering](CLI.md#moav-start)).
+Every protocol is one or more containers grouped into a docker-compose **profile**. `moav start` reads `ENABLE_*` flags from `.env` and only brings up the profiles whose flag is on (see [CLI → Disabled profiles](CLI.md#moav-start)).
 
 ```
-                      ┌─────────────┐
-                      │   .env      │   ENABLE_* flags
-                      └──────┬──────┘
-                             │
-                  ┌──────────▼──────────┐
-                  │ derive_enabled_     │  moav.sh
-                  │ profiles()          │
-                  └──────────┬──────────┘
-                             │
-        ┌────────────┬───────┼───────┬────────────┬─────────────┐
-        ▼            ▼       ▼       ▼            ▼             ▼
-   ┌────────┐  ┌─────────┐ ┌────┐ ┌─────────┐ ┌─────────┐ ┌──────────┐
-   │ proxy  │  │wireguard│ │xhttp│ │dnstunnel│ │trustnl. │ │ admin    │
-   │ (sing- │  │ + wstun.│ │xray │ │dns-rtr+ │ │trust    │ │ admin+   │
-   │  box)  │  │         │ │     │ │4 tunnels│ │tunnel   │ │ proxy    │
-   └────────┘  └─────────┘ └────┘ └─────────┘ └─────────┘ └──────────┘
-   Reality,    WG-over-WS  VLESS+ dnstt/Slip/ HTTP/2 +    FastAPI +
-   Trojan,                 Reality MasterDNS/ QUIC (TLS)  HTTP Basic
-   Hysteria2,              +XHTTP  XDNS                   auth
-   SS-2022,
-   CDN VLESS+WS
-```
+        .env  (ENABLE_* flags)
+                │
+                ▼
+    Compose profile resolution
+                │
+                ▼  (only enabled profiles start)
 
-Other profiles: `amneziawg`, `telegram` (telemt), `conduit` (Psiphon), `snowflake` (Tor), `gooserelay` (SOCKS5 over Google Apps Script), `monitoring` (Prometheus + Grafana + exporters), `setup` (bootstrap + GeoIP updater), `client` (local testing).
+
+  proxy        sing-box
+                 ├─ Reality (VLESS)
+                 ├─ Trojan
+                 ├─ Hysteria2
+                 ├─ Shadowsocks-2022
+                 └─ CDN VLESS+WS
+
+  xhttp        xray   (VLESS + XHTTP + Reality)
+
+  wireguard    wireguard + wstunnel
+                 (direct UDP + WebSocket fallback)
+
+  amneziawg    amneziawg   (obfuscated WireGuard)
+
+  dnstunnel    dns-router + dnstt + slipstream
+               + masterdns + xray (XDNS)
+                 (all four DNS tunnels share port 53)
+
+  trusttunnel  trusttunnel   (HTTP/2 + QUIC, TLS)
+
+  telegram     telemt   (MTProxy, fake-TLS)
+
+  admin        admin + docker-proxy
+                 (FastAPI dashboard, HTTP Basic auth)
+
+  conduit      psiphon-conduit       ─┐
+  snowflake    snowflake + exporter   ├─ bandwidth donations
+  gooserelay   gooserelay            ─┘
+
+  monitoring   prometheus + grafana
+               + per-protocol exporters
+
+  setup        bootstrap + geoip-updater   (one-shot lifecycle)
+  client       client                      (local testing)
+```
 
 ## DNS-router fan-out
 
-All four DNS tunnels share **port 53** via `dns-router`, a small Go service that fans queries out by subdomain suffix. Each tunnel listens on an internal port; only `dns-router` binds the public port.
+All four DNS tunnels share **port 53** through a small Go service called `dns-router`, which inspects each query's subdomain prefix and forwards to the matching backend. Each tunnel container listens on its own internal port; only `dns-router` binds the public port.
 
 ```
-                         Public 53/udp
-                              │
-                       ┌──────▼──────┐
-                       │ dns-router  │   subdomain-match routing
-                       └──┬──┬──┬──┬─┘
-            t.*           │  │  │  │       x.*
-        ┌──────────┐ s.*  │  │  │  │  m.*  ┌──────────┐
-        │  dnstt   ◄──────┘  │  │  └──────►│ masterdns│
-        │  :5353   │ ┌──────►│  │          │  :5355   │
-        └──────────┘ │       │  └────────► xray :5355
-                ┌────▼────┐  │              (XDNS via FinalMask)
-                │slipstrm │  └────────► (other tunnels can be added)
-                │ :5354   │
-                └─────────┘
+              Public 53/udp
+                   │
+            ┌──────▼──────┐
+            │ dns-router  │
+            └──────┬──────┘
+                   │
+   subdomain routing:
+       t.*  ─────►  dnstt
+       s.*  ─────►  slipstream
+       m.*  ─────►  masterdns
+       x.*  ─────►  xray   (XDNS via FinalMask)
 ```
 
-Add a tunnel only by adding its NS record (`t.` / `s.` / `m.` / `x.`); see [DNS → NS Delegations](DNS.md#steps-36-ns-delegations-for-the-four-dns-tunnels). Disabling a tunnel via `ENABLE_*=false` removes its container; `dns-router` just doesn't route to it.
+Delegating a tunnel only requires adding its NS record (`t.` / `s.` / `m.` / `x.`); see [DNS → NS Delegations](DNS.md#steps-36-ns-delegations-for-the-four-dns-tunnels). Disabling a tunnel via `ENABLE_*=false` removes its container; `dns-router` simply has no backend to forward to.
 
 ## Bundle generation flow
 
@@ -88,32 +104,39 @@ Bundles split into three groups:
 
 ## Monitoring stack
 
-The `monitoring` profile is opt-in. When enabled it adds Prometheus + Grafana plus a per-protocol exporter set; each exporter is in the same profile as its target service, not in `monitoring` itself, so disabling a protocol disables its metrics.
+The `monitoring` profile is opt-in. When enabled, it adds Prometheus + Grafana plus a set of exporters — one per protocol. Each exporter lives in the same Compose profile as its target service (not in `monitoring`), so disabling a protocol takes its metrics down too.
 
 ```
-     ┌─────────────┐
-     │  Prometheus │ ←── scrape ──┐
-     └──────┬──────┘              │
-            │                     │
-            │ recording rules     ├─────► clash-exporter  (sing-box Clash API)
-            │ (Conduit lifetime)  ├─────► singbox-exporter (log parser)
-            ▼                     ├─────► xray-exporter
-     ┌─────────────┐              ├─────► telemt-exporter (REST /v1/health)
-     │   Grafana   │              ├─────► wireguard-exporter
-     │  + dashbds  │              ├─────► amneziawg-exporter
-     └─────────────┘              ├─────► snowflake-exporter (Snowflake profile)
-            ▲                     ├─────► node-exporter (host)
-            │                     └─────► cAdvisor (containers)
-            │
-        Optional: grafana-proxy → Cloudflare CDN
+   Exporters (each in its target's profile)
+     ├── clash-exporter      (sing-box Clash API)
+     ├── singbox-exporter    (log parser)
+     ├── xray-exporter
+     ├── telemt-exporter     (REST /v1/health)
+     ├── wireguard-exporter
+     ├── amneziawg-exporter
+     ├── snowflake-exporter  (snowflake profile)
+     ├── node-exporter       (host metrics)
+     └── cAdvisor            (container metrics)
+                │
+                │ scraped by
+                ▼
+         ┌──────────────┐
+         │  Prometheus  │  + recording rules (e.g. Conduit lifetime)
+         └──────┬───────┘
+                │
+                ▼
+         ┌──────────────┐
+         │   Grafana    │  (+ optional grafana-proxy → Cloudflare CDN)
+         │  dashboards  │
+         └──────────────┘
 ```
 
-Pre-built dashboards land in `configs/monitoring/grafana/dashboards/`. The Conduit lifetime panels depend on `conduit_lifetime.rules.yml` + the offset-watcher pair — see [Monitoring → Conduit lifetime bandwidth](MONITORING.md#conduit-lifetime-bandwidth).
+Pre-built dashboards land in `configs/monitoring/grafana/dashboards/`. The Conduit lifetime panels depend on a recording rule plus an offset watcher — see [Monitoring → Conduit lifetime bandwidth](MONITORING.md#conduit-lifetime-bandwidth).
 
 ## See also
 
 - [Setup Guide](SETUP.md) — step-by-step deployment walkthrough
 - [DNS Configuration](DNS.md) — NS records, resolver-mode vs direct-mode XDNS, port 53
-- [CLI Reference](CLI.md) — every `moav` command, including the profile filtering UX
+- [CLI Reference](CLI.md) — every `moav` command, including the disabled-profile prompt
 - [Supported Protocols](protocols.md) — protocol-level cipher, port, and client-compat detail
 - [Monitoring](MONITORING.md) — dashboards, Conduit lifetime, GeoIP setup

--- a/docs/client-guide-template.html
+++ b/docs/client-guide-template.html
@@ -962,8 +962,11 @@
                 </div>
 
                 <!-- WireGuard over WebSocket (wstunnel) -->
-                <div class="extra-section" style="margin-top: 20px; border: 1px solid var(--accent-orange); background: rgba(210, 153, 34, 0.1);">
-                    <h4 style="color: var(--accent-orange);">WireGuard over WebSocket (For Censored Networks)</h4>
+                <details class="extra-section" style="margin-top: 20px; border: 1px solid var(--accent-orange); background: rgba(210, 153, 34, 0.1);">
+                    <summary style="cursor: pointer; list-style: none; padding-block: 6px;">
+                        <h4 style="color: var(--accent-orange); display: inline-block; margin: 0;">WireGuard over WebSocket (For Censored Networks)</h4>
+                        <span style="float: right; color: var(--accent-orange); font-size: 14px;">▸</span>
+                    </summary>
                     <p>If direct WireGuard is blocked (common in Iran, China, Russia), use wstunnel to wrap WireGuard traffic in a WebSocket connection that looks like normal HTTPS.</p>
 
                     <div style="margin-top: 12px;">
@@ -985,21 +988,21 @@
                         <strong>Mobile Setup:</strong>
                         <p style="color: var(--text-muted); font-size: 12px;">Mobile requires running wstunnel in Termux (Android) or using an app that supports WireGuard-over-WebSocket. For most users, we recommend using Reality or Hysteria2 on mobile instead.</p>
                     </div>
-                </div>
 
-                <div class="qr-section" style="margin-top: 16px;">
-                    <div class="qr-code">
-                        <img src="data:image/png;base64,{{QR_WIREGUARD_WSTUNNEL}}" alt="WireGuard wstunnel QR Code" onerror="this.parentElement.classList.add('qr-missing'); this.parentElement.innerHTML='QR not available<br>Use config below';">
+                    <div class="qr-section" style="margin-top: 16px;">
+                        <div class="qr-code">
+                            <img src="data:image/png;base64,{{QR_WIREGUARD_WSTUNNEL}}" alt="WireGuard wstunnel QR Code" onerror="this.parentElement.classList.add('qr-missing'); this.parentElement.innerHTML='QR not available<br>Use config below';">
+                        </div>
+                        <div class="qr-instructions">
+                            <h4>WireGuard-wstunnel Config</h4>
+                            <p style="font-size: 12px; color: var(--text-muted);">Use this config AFTER starting wstunnel client. Points to localhost instead of server.</p>
+                        </div>
                     </div>
-                    <div class="qr-instructions">
-                        <h4>WireGuard-wstunnel Config</h4>
-                        <p style="font-size: 12px; color: var(--text-muted);">Use this config AFTER starting wstunnel client. Points to localhost instead of server.</p>
+                    <div class="config-box">
+                        <h4>WireGuard-wstunnel Config File (save as .conf)</h4>
+                        <div class="config-value multiline">{{CONFIG_WIREGUARD_WSTUNNEL}}</div>
                     </div>
-                </div>
-                <div class="config-box">
-                    <h4>WireGuard-wstunnel Config File (save as .conf)</h4>
-                    <div class="config-value multiline">{{CONFIG_WIREGUARD_WSTUNNEL}}</div>
-                </div>
+                </details>
             </div>
         </div>
 
@@ -1240,6 +1243,10 @@
                 <div class="extra-section">
                     <h4>Quick Setup</h4>
                     <p>Tap/click the link below to add the proxy to your Telegram app:</p>
+                    <p style="margin: 8px 0 12px 0;">
+                        <a href="{{CONFIG_TELEMT}}" target="_blank" style="display: inline-block; padding: 10px 16px; background: var(--accent-primary); color: #fff; border-radius: 6px; text-decoration: none; font-weight: 600;">Open in Telegram</a>
+                    </p>
+                    <p style="font-size: 12px; color: var(--text-muted); margin-bottom: 6px;">Or copy the link manually:</p>
                     <div class="config-value" onclick="copyConfig(this)">{{CONFIG_TELEMT}}</div>
                 </div>
 
@@ -1261,14 +1268,14 @@
         </div>
 
         <!-- Tor -->
-        <div class="protocol-section" id="tor-en">
-            <div class="protocol-header">
+        <details class="protocol-section" id="tor-en">
+            <summary class="protocol-header">
                 <div class="protocol-title">
                     <h2>10. Tor</h2>
                     <span class="protocol-badge badge-standalone">Standalone</span>
                 </div>
                 <span class="protocol-port">Various</span>
-            </div>
+            </summary>
             <div class="protocol-content">
                 <p class="protocol-desc">The Tor network provides anonymous access to the internet. Does not require your MoaV server - connects to the global Tor network.</p>
 
@@ -1287,17 +1294,17 @@
                     <p>Use <strong>bridges</strong> in Tor Browser settings. Select "Snowflake" or "obfs4" bridges which are harder to detect.</p>
                 </div>
             </div>
-        </div>
+        </details>
 
         <!-- Psiphon -->
-        <div class="protocol-section" id="psiphon-en">
-            <div class="protocol-header">
+        <details class="protocol-section" id="psiphon-en">
+            <summary class="protocol-header">
                 <div class="protocol-title">
                     <h2>11. Psiphon</h2>
                     <span class="protocol-badge badge-standalone">Standalone</span>
                 </div>
                 <span class="protocol-port">Various</span>
-            </div>
+            </summary>
             <div class="protocol-content">
                 <p class="protocol-desc">Free circumvention tool with its own network. Does not require your MoaV server - connects to Psiphon's global infrastructure.</p>
 
@@ -1321,7 +1328,7 @@
                     </ol>
                 </div>
             </div>
-        </div>
+        </details>
 
         <!-- Apps Section -->
         <div class="apps-section" id="apps-en">
@@ -1856,8 +1863,11 @@
                 </div>
 
                 <!-- WireGuard over WebSocket (wstunnel) -->
-                <div class="extra-section" style="margin-top: 20px; border: 1px solid var(--accent-orange); background: rgba(210, 153, 34, 0.1);">
-                    <h4 style="color: var(--accent-orange);">WireGuard از طریق WebSocket (برای شبکه‌های سانسور شده)</h4>
+                <details class="extra-section" style="margin-top: 20px; border: 1px solid var(--accent-orange); background: rgba(210, 153, 34, 0.1);">
+                    <summary style="cursor: pointer; list-style: none; padding-block: 6px;">
+                        <h4 style="color: var(--accent-orange); display: inline-block; margin: 0;">WireGuard از طریق WebSocket (برای شبکه‌های سانسور شده)</h4>
+                        <span style="float: left; color: var(--accent-orange); font-size: 14px;">▸</span>
+                    </summary>
                     <p>اگر WireGuard مستقیم مسدود است (رایج در ایران، چین، روسیه)، از wstunnel استفاده کنید تا ترافیک WireGuard را در یک اتصال WebSocket که شبیه HTTPS معمولی است پنهان کنید.</p>
 
                     <div style="margin-top: 12px;">
@@ -1879,21 +1889,21 @@
                         <strong>راه‌اندازی موبایل:</strong>
                         <p style="color: var(--text-muted); font-size: 12px;">برای موبایل نیاز به اجرای wstunnel در Termux (Android) است. برای اکثر کاربران، توصیه می‌کنیم در موبایل از Reality یا Hysteria2 استفاده کنید.</p>
                     </div>
-                </div>
 
-                <div class="qr-section" style="margin-top: 16px;">
-                    <div class="qr-code">
-                        <img src="data:image/png;base64,{{QR_WIREGUARD_WSTUNNEL}}" alt="QR Code WireGuard wstunnel" onerror="this.parentElement.classList.add('qr-missing'); this.parentElement.innerHTML='QR در دسترس نیست<br>از کانفیگ زیر استفاده کنید';">
+                    <div class="qr-section" style="margin-top: 16px;">
+                        <div class="qr-code">
+                            <img src="data:image/png;base64,{{QR_WIREGUARD_WSTUNNEL}}" alt="QR Code WireGuard wstunnel" onerror="this.parentElement.classList.add('qr-missing'); this.parentElement.innerHTML='QR در دسترس نیست<br>از کانفیگ زیر استفاده کنید';">
+                        </div>
+                        <div class="qr-instructions">
+                            <h4>کانفیگ WireGuard-wstunnel</h4>
+                            <p style="font-size: 12px; color: var(--text-muted);">این کانفیگ را بعد از اجرای wstunnel client استفاده کنید. به localhost اشاره می‌کند.</p>
+                        </div>
                     </div>
-                    <div class="qr-instructions">
-                        <h4>کانفیگ WireGuard-wstunnel</h4>
-                        <p style="font-size: 12px; color: var(--text-muted);">این کانفیگ را بعد از اجرای wstunnel client استفاده کنید. به localhost اشاره می‌کند.</p>
+                    <div class="config-box">
+                        <h4>فایل کانفیگ WireGuard-wstunnel (ذخیره با پسوند .conf)</h4>
+                        <div class="config-value multiline">{{CONFIG_WIREGUARD_WSTUNNEL}}</div>
                     </div>
-                </div>
-                <div class="config-box">
-                    <h4>فایل کانفیگ WireGuard-wstunnel (ذخیره با پسوند .conf)</h4>
-                    <div class="config-value multiline">{{CONFIG_WIREGUARD_WSTUNNEL}}</div>
-                </div>
+                </details>
             </div>
         </div>
 
@@ -2130,7 +2140,11 @@
 
                 <div class="extra-section">
                     <h4>راه‌اندازی سریع</h4>
-                    <p>روی لینک زیر بزنید تا پروکسی به اپلیکیشن تلگرام شما اضافه شود:</p>
+                    <p>روی دکمه زیر بزنید تا پروکسی به اپلیکیشن تلگرام شما اضافه شود:</p>
+                    <p style="margin: 8px 0 12px 0;">
+                        <a href="{{CONFIG_TELEMT}}" target="_blank" style="display: inline-block; padding: 10px 16px; background: var(--accent-primary); color: #fff; border-radius: 6px; text-decoration: none; font-weight: 600;">باز کردن در تلگرام</a>
+                    </p>
+                    <p style="font-size: 12px; color: var(--text-muted); margin-bottom: 6px;">یا لینک را به صورت دستی کپی کنید:</p>
                     <div class="config-value" onclick="copyConfig(this)">{{CONFIG_TELEMT}}</div>
                 </div>
 
@@ -2152,14 +2166,14 @@
         </div>
 
         <!-- Tor -->
-        <div class="protocol-section" id="tor-fa">
-            <div class="protocol-header">
+        <details class="protocol-section" id="tor-fa">
+            <summary class="protocol-header">
                 <div class="protocol-title">
                     <h2>۱۰. Tor</h2>
                     <span class="protocol-badge badge-standalone">مستقل</span>
                 </div>
                 <span class="protocol-port">مختلف</span>
-            </div>
+            </summary>
             <div class="protocol-content">
                 <p class="protocol-desc">شبکه Tor دسترسی ناشناس به اینترنت فراهم می‌کند. نیازی به سرور MoaV شما ندارد.</p>
 
@@ -2177,17 +2191,17 @@
                     <p>از <strong>پل‌ها (bridges)</strong> در تنظیمات استفاده کنید. پل‌های "Snowflake" یا "obfs4" را انتخاب کنید.</p>
                 </div>
             </div>
-        </div>
+        </details>
 
         <!-- Psiphon -->
-        <div class="protocol-section" id="psiphon-fa">
-            <div class="protocol-header">
+        <details class="protocol-section" id="psiphon-fa">
+            <summary class="protocol-header">
                 <div class="protocol-title">
                     <h2>۱۱. Psiphon</h2>
                     <span class="protocol-badge badge-standalone">مستقل</span>
                 </div>
                 <span class="protocol-port">مختلف</span>
-            </div>
+            </summary>
             <div class="protocol-content">
                 <p class="protocol-desc">ابزار رایگان دور زدن فیلترینگ با شبکه خودش. نیازی به سرور MoaV شما ندارد.</p>
 
@@ -2200,7 +2214,7 @@
                     </ul>
                 </div>
             </div>
-        </div>
+        </details>
 
         <!-- Apps Section -->
         <div class="apps-section" id="apps-fa">

--- a/docs/mahsanet.md
+++ b/docs/mahsanet.md
@@ -121,8 +121,8 @@ MasterDNS tab**, and MoaV can run the matching MasterDNS server:
 
 1. MasterDNS is **enabled by default** (`ENABLE_MASTERDNS=true`) — just add
    the `m` NS record (see
-   [DNS.md → Step 6](DNS.md#step-6-ns-delegation-for-masterdns)) and
-   rebootstrap. (Set `ENABLE_MASTERDNS=false` only if you want to opt out.)
+   [DNS.md → NS Delegations](DNS.md#steps-36-ns-delegations-for-the-four-dns-tunnels))
+   and rebootstrap. (Set `ENABLE_MASTERDNS=false` only if you want to opt out.)
 2. The user's bundle gets `masterdns-instructions.txt` with the domain +
    encryption key. Enter those in MahsaNG's MasterDNS section.
 

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -1,12 +1,10 @@
 # Mission & Philosophy
 
-## Why MoaV Exists
+Internet freedom doesn't happen by accident. It doesn't come from governments deciding to be generous, or from corporations choosing not to surveil. It comes from people — engineers, activists, diaspora communities, strangers with a spare VPS — building the infrastructure that makes it real.
 
-MoaV was created to **democratize access to anti-censorship tools**. Running a VPN server shouldn't require deep technical expertise. Running *multiple* protocols — so users can find one that works when others are blocked — shouldn't require managing a dozen separate tools.
+We built MoaV because the tools already existed but the friction was too high. Running a reliable multi-protocol circumvention server shouldn't require a week of configuration and a systems-engineering background. With MoaV it takes ten minutes. One command. A $5 server. And you're part of the network that keeps people connected when their governments decide they shouldn't be.
 
-MoaV packages 16+ distinct protocols into a single deployment. When a government blocks one protocol, users switch to another. When that gets blocked too, there's always a fallback. DNS tunnels, CDN-fronted connections, obfuscated WireGuard, Telegram proxies — each has different network characteristics that make them resistant to different blocking techniques.
-
-**The goal is simple:** make it as easy as possible for anyone with a $5/month VPS to provide reliable internet access to people who need it.
+This is not someone else's problem to solve. The window to act is between blackouts, not during them.
 
 ## Internet Access Is a Human Right
 
@@ -16,71 +14,146 @@ The United Nations Human Rights Council has repeatedly affirmed that the same ri
 
 Internet shutdowns are not abstract policy debates. They cut people off from family, healthcare information, financial services, education, and the ability to document what is happening around them. They are used deliberately during protests and crises — precisely when communication matters most.
 
+## Why MoaV Exists
+
+MoaV was created to **democratize access to anti-censorship tools**. Running a VPN server shouldn't require deep technical expertise. Running *multiple* protocols — so users can find one that works when others are blocked — shouldn't require managing a dozen separate tools.
+
+MoaV packages 16+ distinct protocols into a single deployment. One command deploys all of them. A $5 VPS is enough. The goal is simple: make it as easy as possible for anyone with a spare server to provide reliable internet access to people who need it.
+
+## What Infrastructure Actually Means
+
+Here is the difference between using a tool and being infrastructure.
+
+**Using a tool**: you install a VPN app. It works, or it doesn't. When it gets blocked, you try the next one. You are a consumer of access.
+
+**Being infrastructure**: you run a server. Other people connect through it. When the protocols they're using get blocked, your server already has the fallback ready. You are a node in the network of free communication.
+
+MoaV was built to make the second thing as easy as the first.
+
 ## Why Multi-Protocol Matters
 
-No single protocol survives all censorship regimes. Governments invest heavily in Deep Packet Inspection (DPI) and actively adapt their blocking:
+No single protocol survives all censorship regimes. Governments invest heavily in Deep Packet Inspection (DPI) and adapt their blocking continuously:
 
-- **Protocol whitelisting** — Only DNS, HTTP, and HTTPS traffic allowed. Everything else dropped.
+- **Protocol whitelisting** — only DNS, HTTP, and HTTPS allowed; everything else dropped.
 - **SNI inspection** — TLS handshakes inspected to block connections to non-approved domains.
-- **QUIC/UDP blocking** — All UDP traffic except DNS dropped, killing WireGuard and Hysteria2.
-- **Active probing** — Censors connect to suspected proxy servers to verify if they're running proxy software.
-- **Bandwidth throttling** — Connections not outright blocked but throttled to unusable speeds.
+- **QUIC/UDP blocking** — all UDP except DNS dropped, killing WireGuard and Hysteria2.
+- **Active probing** — censors connect to suspected proxy servers to verify they're running proxy software.
+- **Throttling** — connections not outright blocked but throttled to unusable speeds.
 
-MoaV's approach: run everything. Reality looks like a TLS connection to Google. Hysteria2 uses QUIC with obfuscation. WireGuard tunnels through WebSocket when UDP is blocked. DNS tunnels encode traffic in DNS queries. CDN mode routes through Cloudflare. Each protocol exploits a different gap in the censor's capabilities.
+MoaV's approach: run everything. Each protocol exploits a different gap in the censor's capabilities.
 
-See [Supported Protocols](protocols.md) for the full list.
-
-## Iran's Internet Shutdowns
-
-Iran has one of the most sophisticated internet censorship systems in the world. MoaV was built with this reality in mind.
-
-### Timeline
-
-**November 2019** — Near-total internet shutdown during fuel price protests. The government cut connectivity for approximately one week. Amnesty International documented at least 304 deaths during the protests; other estimates are significantly higher. The shutdown prevented documentation of events and coordination of emergency response.
-
-**September 2022 – 2023: Mahsa (Jina) Amini and the Woman, Life, Freedom Movement** — Following Mahsa Amini's death in morality police custody on September 16, 2022, nationwide protests erupted. The government responded with months of internet disruption:
-
-- Mobile data shut down repeatedly across multiple provinces
-- WhatsApp, Instagram, and Signal blocked nationwide
-- International bandwidth throttled to near-unusable levels
-- VPN protocols systematically identified and blocked via DPI
-- Starlink connections jammed in some areas
-
-The movement, known as *"Zan, Zendegi, Azadi"* (Woman, Life, Freedom), saw hundreds killed and thousands arrested. Internet restrictions continued through 2023.
-
-**January 2026** — Multi-day nationwide blackout during mass protests. An estimated 30,000 to 70,000 people were killed. International connectivity dropped to near zero. Only the National Information Network (NIN, the domestic intranet) remained partially functional.
-
-**February – March 2026** — Continued internet disruptions amid regional tensions. International bandwidth throttled heavily, with periodic full outages. Protocol-level blocking intensified, with authorities expanding their DPI capabilities to target newer circumvention tools.
-
-### Technical Censorship Methods
-
-Iran's censorship infrastructure operates at multiple layers:
-
-- **National Information Network (NIN)** — A domestic intranet that continues functioning during international shutdowns, giving authorities the ability to cut external access while maintaining internal services.
-- **Deep Packet Inspection** — Deployed at major peering points to inspect TLS SNI fields, detect proxy protocol signatures, and identify VPN traffic patterns.
-- **Protocol whitelisting** — During heavy censorship periods, only DNS (port 53), HTTP (port 80), and HTTPS (port 443) traffic is permitted. All other protocols are dropped.
-- **Active probing** — Suspected proxy servers are actively probed to confirm their function, then blocked by IP.
-- **Throttling** — Rather than blocking outright, international connections are throttled to make them unusable while maintaining the appearance of connectivity.
-
-### Why This Matters for MoaV
-
-Each of MoaV's protocols addresses different aspects of Iran's censorship:
-
-| Censorship Method | MoaV Counter |
-|-------------------|--------------|
+| Censorship method | MoaV counter |
+|---|---|
 | Protocol blocking | Reality mimics legitimate TLS to approved sites |
 | UDP blocking | WireGuard tunneled through WebSocket (TCP) |
 | IP blocking | CDN mode routes through Cloudflare's network |
 | DPI on SNI | TrustTunnel looks like regular HTTPS traffic |
-| Total shutdown | DNS tunnels can work when only DNS is allowed |
-| Active probing | Decoy website serves innocent content to probes |
-| Throttling | Hysteria2's QUIC protocol maximizes throughput on constrained links |
+| Total shutdown | DNS tunnels work when only DNS is allowed |
+| Active probing | Shadowsocks-2022 AEAD ciphers resist probes; decoy site serves innocent content |
+| Throttling | Hysteria2's QUIC maximizes throughput on constrained links |
+
+You don't know which protocol will survive the next shutdown. Neither does the censor. Running all of them is not inefficient — it's the point. See [Supported Protocols](protocols.md) for the full list.
+
+## The Internet Is Closing
+
+In January 2026, Iran went dark.
+
+Not throttled. Not partially blocked. Dark. International connectivity dropped to near zero for days. The only network that kept running was the National Information Network — the domestic intranet Iran had been quietly building for exactly this scenario. External internet: off. Internal surveillance: intact.
+
+The confirmed death toll from the protests that triggered the blackout is somewhere between 30,000 and 70,000. The number is disputed because during a total blackout, there is no one left to document it in real time. That is the point.
+
+This wasn't the first time. In 2019, Iran killed the internet for a week during fuel protests. In 2022, they tried less successfully to go dark during the Woman, Life, Freedom movement. By 2026 the state had learned.
+
+Traffic into Iran has since reached about 60% of pre-January levels. Internet-traffic analyst Doug Madory at Kentik describes the pattern as "erratic" partial restoration — "we do not know what internet will look like in the long run." When connectivity trickled back, VPN demand in Iran surged **934% in a single day**.
+
+The demand had been building the entire time. It just had nowhere to go.
+
+## A Global Pattern
+
+Iran is not alone. Every time a government restricts connectivity, the response is the same — millions of people immediately try to route around it, and most of them don't know how.
+
+- **Uganda**, January 2026 elections: VPN demand spiked **2,557%** after social platforms were blocked.
+- **Nepal**, September 2025: peaked at **2,892%** when social media was banned.
+- **United Kingdom**, July 2025: age-verification rollout drove a single-day spike of **1,987%**.
+- **Myanmar**, February 2021: the military cut the internet hours after the coup. Mobile first. Then broadband. Then only a few whitelisted ports.
+- **Russia**, post-February 2022: didn't cut the internet — they blocked the tools used to circumvent their filtering. Psiphon. Tor. Signal. The lesson: you don't have to turn off the internet to control it; you just have to make resistance unusable.
+- **China**: two decades of the Great Firewall. Protocol after protocol identified, fingerprinted, blocked. VPN vendors in a permanent arms race.
+
+And the laws that seem unthinkable right now keep becoming law in democracies. The EU's Chat Control proposal would mandate client-side scanning of encrypted messages. France has proposed banning end-to-end encryption for apps used to coordinate "criminal" activity. The UK Online Safety Act gives regulators the power to demand backdoors. The infrastructure that keeps communication free in Iran is the same infrastructure that will matter in Europe when those laws come into force.
+
+## The Arms Race Gets Creative
+
+One of the things that gives us hope — and that governments consistently underestimate — is the ingenuity of people building tools to stay connected under pressure.
+
+Every censorship technique creates its own workaround. Block VPN protocols, developers build obfuscated ones. Block obfuscated VPNs, they route through CDNs too large to block. Block CDNs, they build DNS tunnels. Block DNS, and you break your own country's domestic internet.
+
+But the creativity doesn't stop at DNS:
+
+- **[BaleVPN](https://github.com/kookoo1sabzy/BaleVPN)** routes traffic through Bale — Iran's officially approved video-call platform. The tunnel encodes IP traffic as what looks like a Bale voice call. To the network, an approved domestic app doing approved domestic things. To the user, internet access. The government built the infrastructure for its own circumvention.
+- **[GooseRelay](protocols.md#gooserelay)** (native to MoaV since 1.8.0) routes traffic through Google Apps Script. To the censor, an HTTPS request to a Google Workspace serverless function used by millions of businesses. Blocking GooseRelay means blocking Apps Script globally, which means breaking every company and university using it in the country. The cost of the block exceeds the benefit.
+- **[SNI Spoofing](https://github.com/aleskxyz/SNI-Spoofing-Go)** exploits a different seam — the unencrypted hostname in the TLS handshake. A local proxy sends a fake ClientHello with a decoy hostname (say, `microsoft.com`) while the real connection continues underneath. The DPI box sees something benign; the traffic gets through.
+
+The censor's playbook has a finite number of pages. The circumvention community keeps adding new chapters.
+
+## You Are Donating Bandwidth (Or You Could Be)
+
+Three of the donation paths MoaV bundles are not for you. They are for everyone else.
+
+**[Psiphon Conduit](https://psiphon.ca)** turns your server into a relay node for Psiphon users — people who can't reach the app directly and need a trusted intermediary. Psiphon has tens of millions of users in Iran, Russia, Belarus, Venezuela, and dozens of other censored countries. Your VPS becomes part of the network they depend on.
+
+**[Tor Snowflake](https://snowflake.torproject.org/)** does the same for Tor. Your server becomes a Tor bridge — a relay that Tor users can connect to when the public ones are blocked. You're not an exit node; you're handling the first step for someone who otherwise can't reach the network at all.
+
+**[MahsaNet](mahsanet.md)** is the MahsaNG peer network — and it's worth understanding what makes it different. It's not just a relay pool, it's a distribution channel. When you donate your server config to MahsaNet, you're publishing your server's address and credentials to a network that MahsaNG users can query directly from the app. No diaspora contact required. No Telegram group to find. The app discovers your server automatically, the moment it's needed. MahsaNG has its own distribution infrastructure that already reaches the 2 million+ people using the app.
+
+The marginal cost is bandwidth — a few dollars a month at most on a standard VPS plan. The marginal impact is someone being able to say they're alive.
+
+## Iran's Shutdown History
+
+Iran's censorship infrastructure operates at multiple layers: the National Information Network (NIN, the domestic intranet), Deep Packet Inspection at major peering points, protocol whitelisting during heavy periods (only ports 53/80/443 permitted), active probing of suspected proxy servers, and throttling that maintains the appearance of connectivity while making it unusable.
+
+The chronology that shaped MoaV's design:
+
+- **November 2019** — near-total internet shutdown during fuel-price protests. Amnesty International documented at least 304 deaths; other estimates are significantly higher. The shutdown prevented documentation of events and coordination of emergency response.
+- **September 2022 – 2023: Woman, Life, Freedom** — following Mahsa (Jina) Amini's death in morality-police custody, nationwide protests met months of internet disruption: WhatsApp/Instagram/Signal blocked, international bandwidth throttled to near-unusable levels, VPN protocols systematically identified and DPI-blocked, Starlink jammed in some areas. Hundreds killed, thousands arrested.
+- **January 2026** — the multi-day nationwide blackout described above. International connectivity to near zero. Only the NIN remained functional. Casualty estimates: 30,000–70,000.
+- **February – March 2026** — continued disruptions amid regional tensions. Protocol-level blocking intensified, with authorities expanding DPI capabilities to target newer circumvention tools.
+- **May 2026** — partial restoration to ~60% of baseline; erratic, unstable. The pattern that suggests the next shutdown is being planned.
+
+## The Window Is Open. It Won't Stay That Way.
+
+This is the trap. The state allows a partial reopening after protests wind down — enough for people to feel like things are normalizing, enough to seem like the isolation was temporary. Meanwhile, everything the government learned about circumvention tool usage during a blackout goes into improving the next one. Which DNS resolvers kept working. Which protocols leaked through. Which apps people used when everything else was blocked.
+
+That data is now in the hands of the people planning the next shutdown.
+
+The time to build capacity is not during the shutdown. During a shutdown, new server deployments can't reach the people who need them. Domain names can't be shared through a blocked internet. Configuration files can't be distributed when the distribution channels are offline.
+
+**The servers that matter in the next crisis are the ones being deployed right now, while the window is open.**
+
+## The Argument in One Line
+
+Every time a government has tried to cut the internet completely, they've proven why distributed infrastructure matters. And every time, the people who kept the connections alive were engineers and activists who had set up their servers before the crisis — not during it.
+
+We can be those people. Not as a political statement, not as an act of heroism — as a practical decision, made now, that runs in the background and serves people we'll never know.
+
+That's how infrastructure works.
 
 ## Contributing
 
 If you have a VPS and want to help:
 
-1. **[Deploy MoaV](quick-start.md)** and share access with people who need it
-2. **Enable [Conduit](SETUP.md#bandwidth-donation-conduit-snowflake)** to donate bandwidth to Psiphon users worldwide
-3. **Enable [Snowflake](SETUP.md#bandwidth-donation-conduit-snowflake)** to donate bandwidth to Tor users
-4. **[Contribute code](https://github.com/shayanb/MoaV)** — fix bugs, add protocols, improve documentation
+1. **[Deploy MoaV](quick-start.md)** and share access with people who need it.
+2. **[Enable Conduit](SETUP.md#bandwidth-donation-conduit--snowflake)** to relay bandwidth for Psiphon users worldwide.
+3. **[Enable Snowflake](SETUP.md#bandwidth-donation-conduit--snowflake)** to relay bandwidth for Tor users.
+4. **[Donate configs to MahsaNet](mahsanet.md)** so 2M+ MahsaNG users discover your server automatically.
+5. **[Contribute code](https://github.com/shayanb/MoaV)** — fix bugs, add protocols, improve documentation.
+
+## Sources & Further Reading
+
+Numbers and events cited above:
+
+- Iran shutdown timeline, NIN architecture: [NetBlocks](https://netblocks.org/), [Access Now Shutdown Tracker](https://www.accessnow.org/keepiton/)
+- Iran 934% VPN demand surge (May 2026), Uganda 2,557% (Jan 2026), Nepal 2,892% (Sep 2025), UK 1,987% (Jul 2025): [Top10VPN demand statistics](https://www.top10vpn.com/research/vpn-demand-statistics/)
+- Iran 60% restoration analysis: Doug Madory / [Kentik](https://www.kentik.com/), May 2026
+- Mahsa Amini protests: Amnesty International reports, 2022–2023
+- BaleVPN — TCP over Bale voice calls: [github.com/kookoo1sabzy/BaleVPN](https://github.com/kookoo1sabzy/BaleVPN)
+- SNI Spoofing Go — local proxy sending decoy ClientHello: [github.com/aleskxyz/SNI-Spoofing-Go](https://github.com/aleskxyz/SNI-Spoofing-Go)

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -90,7 +90,7 @@ Every censorship technique creates its own workaround. Block VPN protocols, deve
 But the creativity doesn't stop at DNS:
 
 - **[BaleVPN](https://github.com/kookoo1sabzy/BaleVPN)** routes traffic through Bale — Iran's officially approved video-call platform. The tunnel encodes IP traffic as what looks like a Bale voice call. To the network, an approved domestic app doing approved domestic things. To the user, internet access. The government built the infrastructure for its own circumvention.
-- **[GooseRelay](protocols.md#gooserelay)** (native to MoaV since 1.8.0) routes traffic through Google Apps Script. To the censor, an HTTPS request to a Google Workspace serverless function used by millions of businesses. Blocking GooseRelay means blocking Apps Script globally, which means breaking every company and university using it in the country. The cost of the block exceeds the benefit.
+- **[GooseRelay](protocols.md#gooserelay)** (shipped natively in MoaV) routes traffic through Google Apps Script. To the censor, an HTTPS request to a Google Workspace serverless function used by millions of businesses. Blocking GooseRelay means blocking Apps Script globally, which means breaking every company and university using it in the country. The cost of the block exceeds the benefit.
 - **[SNI Spoofing](https://github.com/aleskxyz/SNI-Spoofing-Go)** exploits a different seam — the unencrypted hostname in the TLS handshake. A local proxy sends a fake ClientHello with a decoy hostname (say, `microsoft.com`) while the real connection continues underneath. The DPI box sees something benign; the traffic gets through.
 
 The censor's playbook has a finite number of pages. The circumvention community keeps adding new chapters.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
   - About:
     - Mission & Philosophy: philosophy.md
     - Supported Protocols: protocols.md
+    - Architecture: architecture.md
   - Developer:
     - Protocol Integration: devdocs/PROTOCOL-INTEGRATION-CHECKLIST.md
     - Version Bump Checklist: devdocs/VERSION-BUMP-CHECKLIST.md

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -1,0 +1,25 @@
+# MoaV
+
+> Multi-protocol Internet censorship circumvention stack optimized for hostile network environments. Bundles 16+ transports — Reality (VLESS), Trojan, Hysteria2, XHTTP, Shadowsocks-2022, CDN VLESS+WS, WireGuard (direct + over WebSocket), AmneziaWG, TrustTunnel (HTTP/2+QUIC), Telegram MTProxy, plus four DNS tunnels (dnstt, Slipstream, MasterDNS, XDNS) sharing port 53 through a subdomain-routing daemon. Optional bandwidth donation paths via Psiphon Conduit, Tor Snowflake, and GooseRelay. Single-host Docker Compose deployment with per-user bundle generation (configs, QR codes, V2Ray subscription) and an optional Prometheus + Grafana monitoring stack.
+
+## Docs
+
+- [Quick Start](https://moav.sh/docs/quick-start/): one-command install and minimal first run
+- [Setup Guide](https://moav.sh/docs/SETUP/): full deployment walkthrough — domain, DNS, certbot, ports, firewall, bootstrap
+- [DNS Configuration](https://moav.sh/docs/DNS/): NS delegations for the four DNS tunnels, dns-router fan-out, resolver-mode vs direct-mode XDNS, port 53 freeing
+- [Supported Protocols](https://moav.sh/docs/protocols/): per-protocol cipher, port, transport, client compatibility, and recommended use case
+- [CLI Reference](https://moav.sh/docs/CLI/): every `moav` command, profile filtering, environment variables
+- [Architecture](https://moav.sh/docs/architecture/): container topology, dns-router fan-out, bundle generation flow, monitoring stack
+- [Client Apps](https://moav.sh/docs/CLIENTS/): per-platform setup (MahsaNG, v2rayNG, Hiddify, Streisand, Happ, WireGuard apps)
+- [MahsaNG Import](https://moav.sh/docs/mahsanet/): V2Ray subscription import + MahsaNet donation flow
+- [Monitoring](https://moav.sh/docs/MONITORING/): Grafana dashboards, Conduit lifetime bandwidth, GeoIP setup
+- [VPS Deployment](https://moav.sh/docs/DEPLOY/): provider-specific install paths (Hetzner, Linode, Vultr, DigitalOcean)
+- [Troubleshooting](https://moav.sh/docs/TROUBLESHOOTING/): common failure modes with diagnostic recipes
+- [OPSEC Guide](https://moav.sh/docs/OPSEC/): operator-side hardening and threat-model notes
+
+## Optional
+
+- [GitHub repository](https://github.com/shayanb/MoaV): source, issues, releases
+- [Changelog](https://github.com/shayanb/MoaV/blob/main/CHANGELOG.md): release notes, behavior changes per version
+- [Mission & Philosophy](https://moav.sh/docs/philosophy/): why MoaV exists and what it deliberately avoids
+- [Protocol Integration Checklist](https://moav.sh/docs/devdocs/PROTOCOL-INTEGRATION-CHECKLIST/): contributor guide for adding a new protocol

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -2,6 +2,10 @@
 
 > Multi-protocol Internet censorship circumvention stack optimized for hostile network environments. Bundles 16+ transports — Reality (VLESS), Trojan, Hysteria2, XHTTP, Shadowsocks-2022, CDN VLESS+WS, WireGuard (direct + over WebSocket), AmneziaWG, TrustTunnel (HTTP/2+QUIC), Telegram MTProxy, plus four DNS tunnels (dnstt, Slipstream, MasterDNS, XDNS) sharing port 53 through a subdomain-routing daemon. Optional bandwidth donation paths via Psiphon Conduit, Tor Snowflake, and GooseRelay. Single-host Docker Compose deployment with per-user bundle generation (configs, QR codes, V2Ray subscription) and an optional Prometheus + Grafana monitoring stack.
 
+## Why MoaV exists
+
+- [Mission & Philosophy](https://moav.sh/docs/philosophy/): the ideology — why MoaV exists, the multi-protocol thesis, Iran's shutdown history, why being infrastructure matters
+
 ## Docs
 
 - [Quick Start](https://moav.sh/docs/quick-start/): one-command install and minimal first run
@@ -21,5 +25,4 @@
 
 - [GitHub repository](https://github.com/shayanb/MoaV): source, issues, releases
 - [Changelog](https://github.com/shayanb/MoaV/blob/main/CHANGELOG.md): release notes, behavior changes per version
-- [Mission & Philosophy](https://moav.sh/docs/philosophy/): why MoaV exists and what it deliberately avoids
 - [Protocol Integration Checklist](https://moav.sh/docs/devdocs/PROTOCOL-INTEGRATION-CHECKLIST/): contributor guide for adding a new protocol


### PR DESCRIPTION
Comprehensive docs refresh covering the 1.7.5 → 1.8.2 drift, plus a new architecture page and an llmstxt.org-spec discovery file.

## What changed

### CLI.md

- **Profiles table** rewritten — was 11 rows missing 6 of 13 real Compose profiles (`dnstunnel` composite, `telegram`, `xhttp`, `gooserelay`, `amneziawg`, `monitoring`, `setup`). New 15-row table maps each profile to its services *and* its underlying `ENABLE_*` flag(s).
- **"Profile filtering (1.8.2+)"** subsection added under `moav start` — explains the `DEFAULT_PROFILES` filter, `moav start all` expansion, and the 3-option prompt for disabled profiles. Was only in the CHANGELOG until now.
- **`moav conduit-offsets`** section added — was undocumented since 1.7.9. Covers install/status/uninstall, auto-install behavior, and the `CONDUIT_OFFSETS_AUTOUPDATE=false` opt-out.

### DNS.md

- **Consolidates 4 separate Step 3-6 sections + 2 redundant "all 4 tunnels coexist" notes** into one consolidated table-based section. Net dedupe of ~25 lines. Anchor now lives at `#steps-36-ns-delegations-for-the-four-dns-tunnels`; the one inbound link in `mahsanet.md` is updated.
- **Cloudflare records table** gains the missing `m` and `x` NS rows (had `t` and `s` only, dating back to before MasterDNS and XDNS were added).

### SETUP.md

- **Removed the inline profile bullet list** (was missing `dnstunnel` / `gooserelay` and out of date); cross-links to CLI.md instead.
- **Bootstrap step now mentions 1.8.2 UX**: domain sanitization (`https://t7d.my/` → `t7d.my`), readline editing in the prompt, and the half-configured `.env` resume behavior.

### MONITORING.md

- **"Conduit lifetime bandwidth"** section added — was 100% missing despite shipping since 1.7.9. Documents `conduit_lifetime.rules.yml`, the offset auto-updater, the systemd watcher, and the auto-install behavior. Cross-links to the new `moav conduit-offsets` CLI section.
- **"MoaV - Conduit"** dashboard summary added alongside the existing protocol dashboards.
- **Snowflake exporter profile note** added so operators know why panels go quiet when `ENABLE_SNOWFLAKE=false` (1.8.2 moved the exporter from `[monitoring, all]` to `[snowflake, all]`).

### docs/architecture.md (new)

~120 lines. Three ASCII-diagrammed sections:
- **Container topology** grouped by Compose profile.
- **DNS-router fan-out** — how the four DNS tunnels share port 53 through subdomain routing.
- **Bundle generation flow** — from `moav user add` through the bootstrap container, state volume, and host bundle writer.
- **Monitoring stack** — Prometheus + Grafana + the per-protocol exporter set.

Registered in `mkdocs.yml` under About.

### site/llms.txt (new)

[llmstxt.org-spec](https://llmstxt.org/) discovery file at the site root (deployed to `https://moav.sh/llms.txt` via the existing `deploy-site.yml` workflow):

- One-paragraph project summary (covers all 16 protocols + donation paths + monitoring stack).
- `## Docs` section linking to each main docs page with a one-line description.
- `## Optional` section for GitHub, Changelog, Philosophy, and the contributor checklist.

## Dedupe targets verified

Per the plan's editorial rule (single canonical home + cross-references):

| Fact | Canonical home | Cross-referenced from |
|------|----------------|------------------------|
| Profile / `ENABLE_*` matrix | `CLI.md#profiles` | `SETUP.md`, `architecture.md` |
| DNS-tunnel subdomain routing | `DNS.md` | `architecture.md`, `mahsanet.md` |
| Bootstrap UX (1.8.2) | `SETUP.md#step-5-run-bootstrap` | (mentioned in CLI's profile filtering subsection by reference) |
| Conduit lifetime bandwidth | `MONITORING.md#conduit-lifetime-bandwidth` | `CLI.md` (`moav conduit-offsets`), `architecture.md` |

## Net line change

```
docs/CLI.md        +44
docs/DNS.md        -32
docs/MONITORING.md +19
docs/SETUP.md      -10
docs/mahsanet.md    0
mkdocs.yml         +1
docs/architecture.md   (new, 118 lines)
site/llms.txt          (new, 24 lines)
```

## Verification

- `mkdocs build -d site/docs` (the deploy-site.yml invocation) succeeds; only pre-existing strict-mode warnings remain (two broken `../CHANGELOG.md` references from `SETUP.md` and `TROUBLESHOOTING.md`, plus a handful of in-page anchor mismatches in `OPSEC.md` / `protocols.md` / `CLIENTS.md` / `CLI.md` that predate this PR — happy to fix in a follow-up).
- Profile table cross-checked against `docker compose --profile all config --services` and the case statement in `moav.sh`.
- llms.txt links spot-checked against the current `mkdocs.yml` nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)