### PR TITLE
fix: non-interactive install/bootstrap + xray healthcheck + BBR module detection

### DIFF
--- a/completions/moav.bash
+++ b/completions/moav.bash
@@ -2,8 +2,14 @@
 # Bash/Zsh completion for moav CLI
 # Installed automatically by 'moav install'
 
-# Zsh compatibility
-if [[ -n "$ZSH_VERSION" ]]; then
+# Zsh compatibility. Guard the var with :- so this file is safe to source
+# under `set -u` / `set -euo pipefail` (which moav.sh enables) — otherwise
+# `source completions/moav.bash` aborts with "ZSH_VERSION: unbound variable"
+# and the parent script dies before printing its tail. moav.sh's
+# install_completions tries `source ... 2>/dev/null || true` to recover,
+# but a nounset failure in the sourced file kills the parent shell before
+# `|| true` can run.
+if [[ -n "${ZSH_VERSION:-}" ]]; then
     autoload -U +X bashcompinit && bashcompinit
 fi
 

--- a/completions/moav.bash
+++ b/completions/moav.bash
@@ -2,13 +2,7 @@
 # Bash/Zsh completion for moav CLI
 # Installed automatically by 'moav install'
 
-# Zsh compatibility. Guard the var with :- so this file is safe to source
-# under `set -u` / `set -euo pipefail` (which moav.sh enables) — otherwise
-# `source completions/moav.bash` aborts with "ZSH_VERSION: unbound variable"
-# and the parent script dies before printing its tail. moav.sh's
-# install_completions tries `source ... 2>/dev/null || true` to recover,
-# but a nounset failure in the sourced file kills the parent shell before
-# `|| true` can run.
+# Zsh compatibility — guard for nounset (moav.sh runs under `set -u`).
 if [[ -n "${ZSH_VERSION:-}" ]]; then
     autoload -U +X bashcompinit && bashcompinit
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -725,10 +725,10 @@ services:
     environment:
       - TZ=${TZ:-UTC}
     healthcheck:
-      # `xray test -c` parses the config and verifies the binary loads. Mirrors
-      # the sing-box healthcheck. Without this, the admin UI shows xray as
-      # "unknown" because Docker reports an empty Health.Status field (#117).
-      test: ["CMD", "/usr/local/bin/xray", "test", "-c", "/etc/xray/config.json"]
+      # `xray run -test -c` parses the config and exits 0 if valid. There is
+      # no `xray test` subcommand (it errors "unknown command"), which left
+      # the container permanently unhealthy even while serving fine (#117).
+      test: ["CMD", "/usr/local/bin/xray", "run", "-test", "-c", "/etc/xray/config.json"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/moav.sh
+++ b/moav.sh
@@ -566,7 +566,13 @@ ensure_admin_password() {
         echo -e "${WHITE}Admin dashboard password${NC}"
         echo "  Press Enter to generate a random password, or type your own"
         printf "  Password: "
-        read -r input_password
+        # Tolerate EOF / closed stdin (cloud-init / setsid / `</dev/null`
+        # callers). Without `|| true` the read returns non-zero on EOF and
+        # `set -e` aborts the whole script before we can fall through to
+        # auto-generation — meaning a non-interactive `moav domainless`
+        # never finishes, never invokes bootstrap, no keys are generated.
+        input_password=""
+        read -r input_password || true
         if [[ -z "$input_password" ]]; then
             input_password=$(openssl rand -base64 16 | tr -dc 'a-zA-Z0-9' | head -c 16)
         fi

--- a/moav.sh
+++ b/moav.sh
@@ -2590,11 +2590,20 @@ ZONEOF
 
 NT_CONF_PATH="/etc/sysctl.d/99-moav-net.conf"
 
-# Returns 0 if the running kernel exposes BBR in tcp_available_congestion_control.
-# OpenVZ guests + ancient kernels (<4.9) will fail this and we skip cleanly.
+# Returns 0 if the running kernel can use BBR. On most distro kernels tcp_bbr
+# ships as a module that isn't loaded until requested, so it's absent from
+# tcp_available_congestion_control on a fresh boot — try modprobe before
+# concluding it's unsupported. OpenVZ guests + ancient kernels (<4.9) still
+# fail cleanly.
 nt_kernel_supports_bbr() {
     local avail
     avail=$(cat /proc/sys/net/ipv4/tcp_available_congestion_control 2>/dev/null || echo "")
+    if [[ " $avail " != *" bbr "* ]]; then
+        local SUDO=""
+        [[ "$(id -u)" -ne 0 ]] && command -v sudo &>/dev/null && SUDO="sudo"
+        $SUDO modprobe tcp_bbr 2>/dev/null || true
+        avail=$(cat /proc/sys/net/ipv4/tcp_available_congestion_control 2>/dev/null || echo "")
+    fi
     [[ " $avail " == *" bbr "* ]]
 }
 
@@ -2678,6 +2687,10 @@ nt_apply() {
     fi
     rm -f "$tmp"
 
+    # Persist the module so bbr survives reboot even if nothing else pulls it
+    # in before sysctl runs.
+    echo "tcp_bbr" | $SUDO tee /etc/modules-load.d/moav-bbr.conf >/dev/null 2>&1 || true
+
     if $SUDO sysctl -p "$NT_CONF_PATH" >/dev/null 2>&1; then
         success "Network tuning applied → $NT_CONF_PATH (buffer max: $((bmax / 1048576)) MiB)"
         return 0
@@ -2704,6 +2717,7 @@ nt_revert() {
     fi
 
     $SUDO rm -f "$NT_CONF_PATH"
+    $SUDO rm -f /etc/modules-load.d/moav-bbr.conf 2>/dev/null || true
     # Re-load the rest of sysctl.d (and main sysctl.conf) so the kernel reverts
     # to distro defaults / whatever else is configured. Best-effort.
     $SUDO sysctl --system >/dev/null 2>&1 || true

--- a/moav.sh
+++ b/moav.sh
@@ -118,7 +118,16 @@ version_gt() {
 }
 
 print_header() {
-    clear
+    # Guard `clear` against non-TTY stdout (cloud-init, nohup, setsid, CI):
+    # without TERM set, ncurses' clear exits non-zero AND prints
+    # "TERM environment variable not set." — under our `set -euo pipefail`
+    # that tears down the whole script (this is exactly what kills
+    # `setsid bash -c "./moav.sh domainless </dev/null"` mid-banner).
+    # Skip the clear when stdout isn't a TTY; there's no terminal state
+    # to wipe anyway.
+    if [[ -t 1 ]]; then
+        clear 2>/dev/null || true
+    fi
     # Get current branch
     local branch
     branch=$(git -C "$SCRIPT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")

--- a/moav.sh
+++ b/moav.sh
@@ -118,13 +118,7 @@ version_gt() {
 }
 
 print_header() {
-    # Guard `clear` against non-TTY stdout (cloud-init, nohup, setsid, CI):
-    # without TERM set, ncurses' clear exits non-zero AND prints
-    # "TERM environment variable not set." — under our `set -euo pipefail`
-    # that tears down the whole script (this is exactly what kills
-    # `setsid bash -c "./moav.sh domainless </dev/null"` mid-banner).
-    # Skip the clear when stdout isn't a TTY; there's no terminal state
-    # to wipe anyway.
+    # Only clear when stdout is a TTY (avoids "TERM not set" abort under setsid).
     if [[ -t 1 ]]; then
         clear 2>/dev/null || true
     fi
@@ -566,13 +560,8 @@ ensure_admin_password() {
         echo -e "${WHITE}Admin dashboard password${NC}"
         echo "  Press Enter to generate a random password, or type your own"
         printf "  Password: "
-        # Tolerate EOF / closed stdin (cloud-init / setsid / `</dev/null`
-        # callers). Without `|| true` the read returns non-zero on EOF and
-        # `set -e` aborts the whole script before we can fall through to
-        # auto-generation — meaning a non-interactive `moav domainless`
-        # never finishes, never invokes bootstrap, no keys are generated.
         input_password=""
-        read -r input_password || true
+        read -r input_password || true   # EOF on closed stdin → fall through to auto-gen
         if [[ -z "$input_password" ]]; then
             input_password=$(openssl rand -base64 16 | tr -dc 'a-zA-Z0-9' | head -c 16)
         fi

--- a/site/install.sh
+++ b/site/install.sh
@@ -65,8 +65,14 @@ confirm() {
     local prompt="${1:-Continue?}"
     local default="${2:-n}"
 
-    # Check if we have a TTY for interactive input
-    if [[ ! -t 0 ]] && [[ ! -e /dev/tty ]]; then
+    # Check if we have a TTY for interactive input. We can't just stat
+    # /dev/tty with -e: under setsid (cloud-init, detached nohup, CI
+    # runners) the device node exists but opening it returns ENXIO,
+    # so the prompt then prints "bash: /dev/tty: No such device or
+    # address" and the read fallback runs anyway — but the error
+    # message leaks to the operator and confuses anything tailing the
+    # log. Actually try to OPEN the device in a subshell instead.
+    if [[ ! -t 0 ]] && ! { : < /dev/tty; } 2>/dev/null; then
         # Non-interactive: use default
         [[ "$default" == "y" ]]
         return
@@ -79,7 +85,11 @@ confirm() {
         printf "%s [y/N] " "$prompt"
     fi
 
-    if read -n 1 -r REPLY < /dev/tty 2>/dev/null; then
+    # The whole read+redirect is grouped in {…} so the redirect failure
+    # under setsid (where /dev/tty is unopenable) is captured by the
+    # surrounding stderr redirect — otherwise bash emits a redirect
+    # error message before the read even runs.
+    if { read -n 1 -r REPLY < /dev/tty; } 2>/dev/null; then
         echo ""
     else
         # Fallback if /dev/tty fails - use default

--- a/site/install.sh
+++ b/site/install.sh
@@ -65,15 +65,9 @@ confirm() {
     local prompt="${1:-Continue?}"
     local default="${2:-n}"
 
-    # Check if we have a TTY for interactive input. We can't just stat
-    # /dev/tty with -e: under setsid (cloud-init, detached nohup, CI
-    # runners) the device node exists but opening it returns ENXIO,
-    # so the prompt then prints "bash: /dev/tty: No such device or
-    # address" and the read fallback runs anyway — but the error
-    # message leaks to the operator and confuses anything tailing the
-    # log. Actually try to OPEN the device in a subshell instead.
+    # Detect interactivity by actually opening /dev/tty — under setsid the
+    # device node exists but opening returns ENXIO, so -e would lie.
     if [[ ! -t 0 ]] && ! { : < /dev/tty; } 2>/dev/null; then
-        # Non-interactive: use default
         [[ "$default" == "y" ]]
         return
     fi
@@ -85,14 +79,10 @@ confirm() {
         printf "%s [y/N] " "$prompt"
     fi
 
-    # The whole read+redirect is grouped in {…} so the redirect failure
-    # under setsid (where /dev/tty is unopenable) is captured by the
-    # surrounding stderr redirect — otherwise bash emits a redirect
-    # error message before the read even runs.
+    # Group the redirect so bash's redirect error is captured by 2>/dev/null.
     if { read -n 1 -r REPLY < /dev/tty; } 2>/dev/null; then
         echo ""
     else
-        # Fallback if /dev/tty fails - use default
         echo ""
         [[ "$default" == "y" ]]
         return

--- a/site/install.sh
+++ b/site/install.sh
@@ -526,9 +526,14 @@ maybe_offer_net_tuning() {
     # Already applied (re-install / re-run) — skip silently.
     [[ -f "$NT_CONF" ]] && return 0
 
-    # Kernel must expose BBR (mainline since 4.9; OpenVZ doesn't).
+    # Kernel must expose BBR (mainline since 4.9; OpenVZ doesn't). It's usually
+    # a module that's absent from the list until loaded — try modprobe first.
     local avail
     avail=$(cat /proc/sys/net/ipv4/tcp_available_congestion_control 2>/dev/null || echo "")
+    if [[ " $avail " != *" bbr "* ]]; then
+        ${SUDO:-} modprobe tcp_bbr 2>/dev/null || sudo modprobe tcp_bbr 2>/dev/null || true
+        avail=$(cat /proc/sys/net/ipv4/tcp_available_congestion_control 2>/dev/null || echo "")
+    fi
     if [[ " $avail " != *" bbr "* ]]; then
         # Quiet skip — operator can't do anything about a missing-BBR kernel.
         return 0


### PR DESCRIPTION
Found + fixed while deploying the `dev` branch to a fresh Ubuntu 24.04 VPS via `install.sh` and bringing it up in domainless mode. Several issues only surface on a non-interactive (setsid / `</dev/null`) bootstrap, plus two that affect every host.

## Fixes

**1. `completions/moav.bash` — `$ZSH_VERSION` unbound under `set -u`**
`moav.sh` runs `set -euo pipefail`. `install_completions` sources the completion file, whose first line tests `[[ -n "$ZSH_VERSION" ]]`. Under bash that variable is unset → nounset aborts the parent shell before the `source ... || true` rescue. `moav install` exits 1. → `${ZSH_VERSION:-}`.

**2. `install.sh` — `[[ -e /dev/tty ]]` misdetects setsid**
Under setsid the device node exists but opening it returns ENXIO, so the interactive path runs and leaks `bash: /dev/tty: No such device or address`. Detect by actually opening the device; group the `read` redirect so the error is captured.

**3. `moav.sh` `print_header` — `clear` aborts when `TERM` unset**
Every `cmd_*` calls `print_header` → `clear`. Without TERM, ncurses `clear` exits non-zero + prints "TERM environment variable not set." → `set -e` tears the script down. Only `clear` when stdout is a TTY.

**4. `moav.sh` `ensure_admin_password` — `read` aborts on EOF**
`read -r input_password` returns non-zero on closed stdin (`</dev/null`); `set -e` aborts before the auto-generate fallback. The empty case is meant to be valid → `|| true`.

**5. `docker-compose.yml` — xray healthcheck uses nonexistent `xray test`**
`xray test -c` errors "unknown command", exit 2 → container permanently unhealthy while proxying fine. Correct invocation is `xray run -test -c` ("Configuration OK", exit 0). Verified on xray 26.5.9.

**6. `moav.sh` + `install.sh` — BBR detection misses module-based kernels**
`tcp_bbr` is a loadable module on most distro kernels, absent from `tcp_available_congestion_control` until loaded. Detection read that list on a fresh boot and concluded "BBR not available", skipping network tuning entirely on kernels that fully support it (6.8 / Ubuntu 24.04). Now `modprobe tcp_bbr` before checking, and persist via `/etc/modules-load.d/moav-bbr.conf` (removed on `net revert`).

## Verified on a fresh Ubuntu 24.04 VPS (kernel 6.8)

- `setsid bash -c "... install.sh ... </dev/null"` → exit 0, full banner
- `moav domainless` (non-interactive) → bootstrap runs, Reality/WG/SS keys generated, demouser bundle produced
- All domainless protocols proxy end-to-end (egress IP = server): Reality, XHTTP, Shadowsocks-2022, WireGuard
- `moav xray` healthy after fix #5
- `moav net apply` → `cc=bbr qdisc=fq rmem_max=32MiB`, module loaded + persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)