### PR TITLE
chore: trim verbose comments from v1.8.4 work

### DIFF
--- a/admin/main.py
+++ b/admin/main.py
@@ -145,9 +145,8 @@ def verify_auth(request: Request, credentials: HTTPBasicCredentials = Depends(se
     return credentials.username
 
 
-# Dashboard service name → docker container name. One source of truth.
-# Keep in sync with all_services in get_services_status() and with
-# `container_name:` fields in docker-compose.yml.
+# Service name → container name. Keep in sync with all_services in
+# get_services_status() and docker-compose.yml `container_name:` fields.
 SERVICE_CONTAINERS = {
     "sing-box":    "moav-sing-box",
     "decoy":       "moav-decoy",
@@ -169,14 +168,8 @@ SERVICE_CONTAINERS = {
 
 
 def _fetch_running_containers():
-    """Query docker-socket-proxy for the set of currently-running container
-    names. Returns a set on success, or None on any error so callers can
-    surface "unknown" instead of mis-reporting everything as stopped.
-
-    /containers/json returns only running containers by default (no `all=1`).
-    The admin container has DOCKER_HOST=tcp://docker-proxy:2375 set in
-    docker-compose.yml, and docker-proxy has CONTAINERS=1 capability.
-    """
+    """Set of running container names via docker-socket-proxy, or None on error
+    (so callers surface "unknown" instead of falsely "stopped")."""
     base = os.environ.get("DOCKER_HOST", "tcp://docker-proxy:2375").replace("tcp://", "http://")
     try:
         resp = httpx.get(f"{base}/containers/json", timeout=1.5)
@@ -184,7 +177,7 @@ def _fetch_running_containers():
             return None
         names = set()
         for c in resp.json():
-            # /containers/json returns names with a leading slash, e.g. "/moav-xray".
+            # /containers/json names have a leading slash, e.g. "/moav-xray".
             for n in c.get("Names", []):
                 names.add(n.lstrip("/"))
         return names
@@ -193,16 +186,8 @@ def _fetch_running_containers():
 
 
 def check_service_status(name: str, _running=None) -> str:
-    """Check whether a service's container is running.
-
-    Uniform docker-socket-proxy lookup. One round-trip lists every running
-    container; we cross-reference against SERVICE_CONTAINERS. Works for both
-    bridge-networked (moav_net) and host-networked (snowflake) services
-    without per-service special cases.
-
-    `_running` lets get_services_status() pass a pre-fetched set so the dashboard
-    only makes one docker-proxy call per refresh, not one per service card.
-    """
+    """Returns 'running' | 'stopped' | 'unknown'. `_running` lets callers pass
+    a pre-fetched set so a dashboard refresh makes one docker-proxy call total."""
     running = _running if _running is not None else _fetch_running_containers()
     if running is None:
         return "unknown"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -725,9 +725,7 @@ services:
     environment:
       - TZ=${TZ:-UTC}
     healthcheck:
-      # `xray run -test -c` parses the config and exits 0 if valid. There is
-      # no `xray test` subcommand (it errors "unknown command"), which left
-      # the container permanently unhealthy even while serving fine (#117).
+      # `xray run -test` parses config and exits 0; `xray test` does not exist (#117).
       test: ["CMD", "/usr/local/bin/xray", "run", "-test", "-c", "/etc/xray/config.json"]
       interval: 30s
       timeout: 5s

--- a/moav.sh
+++ b/moav.sh
@@ -429,33 +429,22 @@ get_env_val() {
     echo "${val:-$default}"
 }
 
-# -----------------------------------------------------------------------------
-# Reality fallback target — vetted lists + DNS validation (issue #115)
-#
-# Reality's `handshake.server` / `realitySettings.dest` is the host the inbound
-# proxies non-Reality TLS hellos to (the "you didn't auth, here's a real site"
-# fallback). If it doesn't resolve, every probe and every legitimate client
-# sees an RST. Operators historically picked plausible-sounding hostnames
-# (`update.samsung.com`, `swl.samsung.com`) that aren't public DNS names —
-# those bundles silently break.
-# -----------------------------------------------------------------------------
+# Reality fallback target — vetted lists + DNS validation (#115).
+# NXDOMAIN target → every TLS hello RSTs, bundle silently breaks.
 REALITY_TARGETS_GLOBAL=(
     "www.cloudflare.com:443"
     "www.apple.com:443"
     "cdn.kernel.org:443"
     "www.microsoft.com:443"
 )
-# SNI cover for Iran-resident clients — Reality hello looks like normal traffic
-# to Iranian-domestic sites, which Iran DPI is less aggressive about than
-# Western corporate destinations.
+# SNI cover for clients inside Iran.
 REALITY_TARGETS_IRAN=(
     "www.aparat.com:443"
     "digikala.com:443"
     "taghche.com:443"
 )
 
-# Returns 0 if `host` resolves to at least one A or AAAA record. Tries getent,
-# then host, then nslookup — whichever is present. Empty host → fail.
+# 0 if host has A/AAAA. Tries getent → host → nslookup. Empty host → fail.
 reality_target_resolves() {
     local host="$1"
     [[ -n "$host" ]] || return 1
@@ -485,10 +474,8 @@ show_vetted_reality_targets() {
     done
 }
 
-# Validate REALITY_TARGET and XHTTP_REALITY_TARGET from .env resolve in DNS.
-# If a host is NXDOMAIN, prompt for a replacement (up to 3 attempts), rewrite
-# .env in place. Returns 0 on success / all valid, 1 if still invalid after
-# attempts and operator can't fix it. Skips disabled protocols.
+# Validate REALITY_TARGET / XHTTP_REALITY_TARGET resolve. NXDOMAIN → re-prompt
+# (≤3) and rewrite .env. Returns 1 if still invalid after retries.
 validate_reality_targets() {
     local env_file="${1:-.env}"
     [[ -f "$env_file" ]] || return 0  # nothing to validate yet
@@ -2571,30 +2558,13 @@ ZONEOF
 }
 
 # =============================================================================
-# Network tuning — BBR congestion control + buffers + queue depth
-#
-# Real-world Portugal→Vilnius test (Time4VPS, ~400 ms RTT with burst loss):
-# CUBIC 5.45 Mbps → BBR 14.8 Mbps single-flow TCP. Recovery from packet loss
-# went from "CUBIC stuck at 2 Mbps for seconds" to "BBR jumped to 43 Mbps in
-# the next second". UDP buffer bumps help Hysteria2 / WireGuard / quic-go even
-# though they don't use BBR (quic-go needs >=7.5 MiB).
-#
-# Sources: naiveproxy Performance Tuning wiki, Cloudflare TCP tuning blog,
-# Stony Brook IMC'19 "When to use BBR", quic-go UDP Buffer Sizes wiki.
-#
-# `tcp_fastopen` is deliberately NOT set — TFO is hostile in censored networks
-# (~5% of paths drop SYN+data; China Mobile firewalls). See Craig Andrews'
-# "Sad Story of TCP Fast Open" + the same reasoning that removed it from the
-# sing-box Reality / Trojan inbounds in v1.8.4.
+# Network tuning — BBR + buffers + queue depth. Rationale + sources: OPSEC.md.
 # =============================================================================
 
 NT_CONF_PATH="/etc/sysctl.d/99-moav-net.conf"
 
-# Returns 0 if the running kernel can use BBR. On most distro kernels tcp_bbr
-# ships as a module that isn't loaded until requested, so it's absent from
-# tcp_available_congestion_control on a fresh boot — try modprobe before
-# concluding it's unsupported. OpenVZ guests + ancient kernels (<4.9) still
-# fail cleanly.
+# Returns 0 if the kernel can use BBR. tcp_bbr is a module on most distros —
+# modprobe first, otherwise OpenVZ / pre-4.9 kernels both fail cleanly.
 nt_kernel_supports_bbr() {
     local avail
     avail=$(cat /proc/sys/net/ipv4/tcp_available_congestion_control 2>/dev/null || echo "")
@@ -2607,8 +2577,7 @@ nt_kernel_supports_bbr() {
     [[ " $avail " == *" bbr "* ]]
 }
 
-# 16 MiB on hosts <2 GB RAM, 32 MiB otherwise. quic-go needs >=7.5 MiB just for
-# its UDP buffer; 16 MiB headroom matters even on small VPSes.
+# 16 MiB on <2 GB RAM hosts, 32 MiB otherwise (quic-go floor is 7.5 MiB).
 nt_buffer_max() {
     local total_mb
     total_mb=$(awk '/MemTotal/ {printf "%.0f", $2/1024}' /proc/meminfo 2>/dev/null || echo 0)
@@ -2619,41 +2588,35 @@ nt_buffer_max() {
     fi
 }
 
-# Render the sysctl bundle to stdout. Caller writes it to /etc/sysctl.d/.
+# Render the sysctl bundle to stdout. Caller writes it to NT_CONF_PATH.
+# bmax = max for {r,w}mem_max + tcp_{r,w}mem high bound.
 nt_render_config() {
     local bmax="$1"
     cat <<EOF
 # MoaV network tuning — generated $(date -u '+%Y-%m-%d %H:%M:%S UTC')
-# Reversible: moav net revert (deletes this file + reloads sysctl)
-# Docs: docs/OPSEC.md → "Network tuning"
+# Reversible: moav net revert. Docs: docs/OPSEC.md → "Network tuning".
 
-# Congestion control + queue discipline. BBR has been mainline since 4.9;
-# fq is required for BBR's pacing.
+# BBR needs fq for pacing.
 net.ipv4.tcp_congestion_control = bbr
 net.core.default_qdisc          = fq
 
-# TCP buffers — auto-sized per host RAM.
 net.core.rmem_max               = ${bmax}
 net.core.wmem_max               = ${bmax}
 net.ipv4.tcp_rmem               = 4096 131072 ${bmax}
 net.ipv4.tcp_wmem               = 4096 16384 ${bmax}
 
-# UDP/QUIC defaults (Hysteria2, WireGuard, quic-go)
+# UDP defaults (Hysteria2, WireGuard, quic-go)
 net.core.rmem_default           = 1048576
 net.core.wmem_default           = 1048576
 
-# Queue depth — UDP drops hurt circumvention worse than TCP drops.
 net.core.netdev_max_backlog     = 16384
 net.core.somaxconn              = 8192
 
-# Long-lived proxy hygiene
 net.ipv4.tcp_slow_start_after_idle = 0
 net.ipv4.tcp_mtu_probing           = 1
 net.ipv4.tcp_notsent_lowat         = 131072
 
-# DELIBERATELY NOT SET: net.ipv4.tcp_fastopen
-# TFO server-side ADDS latency in heavily-censored networks because
-# middleboxes drop the SYN+data and the client has to retry. See OPSEC.md.
+# tcp_fastopen DELIBERATELY UNSET — middleboxes drop SYN+data, raising latency.
 EOF
 }
 
@@ -2687,8 +2650,7 @@ nt_apply() {
     fi
     rm -f "$tmp"
 
-    # Persist the module so bbr survives reboot even if nothing else pulls it
-    # in before sysctl runs.
+    # Persist tcp_bbr across reboot.
     echo "tcp_bbr" | $SUDO tee /etc/modules-load.d/moav-bbr.conf >/dev/null 2>&1 || true
 
     if $SUDO sysctl -p "$NT_CONF_PATH" >/dev/null 2>&1; then
@@ -2700,8 +2662,7 @@ nt_apply() {
     fi
 }
 
-# Remove the moav tuning file and reload sysctl. Returns 0 even if the file
-# didn't exist (revert is idempotent).
+# Idempotent — returns 0 even if NT_CONF_PATH doesn't exist.
 nt_revert() {
     local SUDO=""
     if [[ "$(id -u)" -ne 0 ]]; then
@@ -2718,17 +2679,14 @@ nt_revert() {
 
     $SUDO rm -f "$NT_CONF_PATH"
     $SUDO rm -f /etc/modules-load.d/moav-bbr.conf 2>/dev/null || true
-    # Re-load the rest of sysctl.d (and main sysctl.conf) so the kernel reverts
-    # to distro defaults / whatever else is configured. Best-effort.
     $SUDO sysctl --system >/dev/null 2>&1 || true
     success "Network tuning reverted (removed $NT_CONF_PATH)."
     echo "  Some settings (rmem_max, wmem_max, congestion_control) only fully reset on reboot."
     return 0
 }
 
-# Print current vs desired values + applied/not-applied marker. Used by both
-# `moav net status` and `doctor_check_net`. Returns 0 if file exists AND core
-# values match, 1 if file present but drifted, 2 if not applied (skipped/unset).
+# Returns 0 = applied + values match, 1 = applied but drifted, 2 = not applied
+# or kernel unsupported. Called by `moav net status` and doctor_check_net.
 nt_status() {
     local pass=true
     local applied=false
@@ -2781,11 +2739,10 @@ nt_status() {
     if [[ "$applied" == "true" ]]; then
         $pass && return 0 || return 1
     else
-        return 2  # not applied — treat as skip in doctor sweep
+        return 2
     fi
 }
 
-# Top-level dispatcher for `moav net <subcommand>`.
 cmd_net() {
     local sub="${1:-status}"
     case "$sub" in
@@ -2847,8 +2804,6 @@ DOCTOR_CHECKS=(
     "updates:Check for MoaV updates"
 )
 
-# Wrapper so the doctor dispatcher can call nt_status without leaking the
-# `net.*` namespace from /proc directly into the checks list.
 doctor_check_net() {
     nt_status
 }
@@ -3688,11 +3643,8 @@ doctor_check_conflicts() {
     $pass && return 0 || return 1
 }
 
-# Reality fallback target check (issue #115).
-# For each enabled Reality inbound, ask its container's resolver whether the
-# configured `dest` hostname resolves, then TCP-probe the port from inside the
-# same container. Falls back to the host resolver if the container isn't
-# running (still useful — operator hasn't started services yet).
+# Reality dest reachability (#115). Uses the container's resolver (matches what
+# Reality sees at handshake); falls back to host resolver when container down.
 doctor_check_reality() {
     local env_file="$SCRIPT_DIR/.env"
     local enable_reality enable_xhttp

--- a/scripts/lib/telemt.sh
+++ b/scripts/lib/telemt.sh
@@ -152,8 +152,7 @@ stun_tcp_fallback = ${stun_tcp_fallback}
 tls_domain = "${tls_domain}"
 mask = true
 tls_emulation = true
-# Absolute path: telemt's cwd is /app/cache (entrypoint changed for #117), and
-# the TLS front cache lives in a separate tmpfs at /app/tlsfront.
+# Absolute — cwd is /app/cache (#117), tlsfront is its own tmpfs.
 tls_front_dir = "/app/tlsfront"
 
 [access.users]

--- a/scripts/telemt-entrypoint.sh
+++ b/scripts/telemt-entrypoint.sh
@@ -39,10 +39,7 @@ echo "================================================"
 # Fix tmpfs directory ownership (mounted as root, telemt runs as moav)
 chown -R moav:moav /app/tlsfront /app/cache 2>/dev/null || true
 
-# Start telemt as moav user. cwd is /app/cache (an existing tmpfs) so the
-# runtime observability snapshot — `beobachten.txt`, written relative to cwd —
-# lands in a writable filesystem instead of failing every 15s against the
-# read-only / root (#117). Config uses an absolute path for tls_front_dir, so
-# the cwd change is safe.
+# cwd → tmpfs so beobachten.txt (written relative to cwd) lands on writable fs
+# instead of failing every 15s against the read-only / root (#117).
 cd /app/cache
 exec su-exec moav telemt "$CONFIG_FILE"

--- a/site/install.sh
+++ b/site/install.sh
@@ -512,32 +512,22 @@ maybe_offer_swap() {
 # Best-effort; never let a swap hiccup abort the installer (set -e is on).
 maybe_offer_swap || true
 
-# =============================================================================
-# Offer BBR + kernel network tuning. Commonly 2–5× TCP throughput on long-RTT
-# or lossy paths (which the Iran-bound proxy use case very much is). Reversible
-# later via `moav net revert`. Same logic ships in moav.sh as `moav net apply`
-# so updates can re-trigger or revert this independently.
-# =============================================================================
+# Offer BBR + kernel network tuning at install time. Mirrors `moav net apply`.
 maybe_offer_net_tuning() {
     [[ "$(uname -s)" == "Linux" ]] || return 0
-    [[ -t 0 || -e /dev/tty ]] || return 0   # skip in non-interactive runs
+    [[ -t 0 || -e /dev/tty ]] || return 0   # non-interactive → skip
 
     local NT_CONF=/etc/sysctl.d/99-moav-net.conf
-    # Already applied (re-install / re-run) — skip silently.
-    [[ -f "$NT_CONF" ]] && return 0
+    [[ -f "$NT_CONF" ]] && return 0   # already applied
 
-    # Kernel must expose BBR (mainline since 4.9; OpenVZ doesn't). It's usually
-    # a module that's absent from the list until loaded — try modprobe first.
+    # tcp_bbr is a module on most distros — modprobe before declaring absent.
     local avail
     avail=$(cat /proc/sys/net/ipv4/tcp_available_congestion_control 2>/dev/null || echo "")
     if [[ " $avail " != *" bbr "* ]]; then
         ${SUDO:-} modprobe tcp_bbr 2>/dev/null || sudo modprobe tcp_bbr 2>/dev/null || true
         avail=$(cat /proc/sys/net/ipv4/tcp_available_congestion_control 2>/dev/null || echo "")
     fi
-    if [[ " $avail " != *" bbr "* ]]; then
-        # Quiet skip — operator can't do anything about a missing-BBR kernel.
-        return 0
-    fi
+    [[ " $avail " != *" bbr "* ]] && return 0
 
     local current_cc
     current_cc=$(cat /proc/sys/net/ipv4/tcp_congestion_control 2>/dev/null || echo "?")
@@ -575,9 +565,9 @@ maybe_offer_net_tuning() {
     tmp=$(mktemp)
     cat > "$tmp" <<EOF
 # MoaV network tuning — generated $(date -u '+%Y-%m-%d %H:%M:%S UTC')
-# Reversible: moav net revert (deletes this file + reloads sysctl)
-# Docs: docs/OPSEC.md → "Network tuning"
+# Reversible: moav net revert. Docs: docs/OPSEC.md → "Network tuning".
 
+# BBR needs fq for pacing.
 net.ipv4.tcp_congestion_control = bbr
 net.core.default_qdisc          = fq
 
@@ -586,6 +576,7 @@ net.core.wmem_max               = ${bmax}
 net.ipv4.tcp_rmem               = 4096 131072 ${bmax}
 net.ipv4.tcp_wmem               = 4096 16384 ${bmax}
 
+# UDP defaults (Hysteria2, WireGuard, quic-go)
 net.core.rmem_default           = 1048576
 net.core.wmem_default           = 1048576
 
@@ -596,9 +587,7 @@ net.ipv4.tcp_slow_start_after_idle = 0
 net.ipv4.tcp_mtu_probing           = 1
 net.ipv4.tcp_notsent_lowat         = 131072
 
-# DELIBERATELY NOT SET: net.ipv4.tcp_fastopen
-# TFO server-side ADDS latency in heavily-censored networks because
-# middleboxes (notably China Mobile) drop SYN+data on ~5% of paths.
+# tcp_fastopen DELIBERATELY UNSET — middleboxes drop SYN+data, raising latency.
 EOF
 
     if $SUDO install -m 0644 "$tmp" "$NT_CONF"; then


### PR DESCRIPTION
Tightens code comments across the v1.8.4 work I added per feedback: keep functional intent + gotcha + error type, drop narrative.

Removed multi-paragraph context blocks like the BBR throughput-test write-up, the "Sad Story of TCP Fast Open" citation, the Reality-NXDOMAIN root-cause explainer, and the docker-socket-proxy capability rundown. Those live in CHANGELOG, OPSEC.md, and PR bodies already.

No behaviour changes — same code paths, just less prose. Net 80 lines removed.

### Files touched

| File | Lines reduced |
|---|---|
| `moav.sh` | network-tuning section + nt_* helpers + Reality validator + doctor_check_net wrapper |
| `site/install.sh` | maybe_offer_net_tuning intro + sysctl bundle inline comments |
| `admin/main.py` | _fetch_running_containers + check_service_status docstrings + SERVICE_CONTAINERS header |
| `docker-compose.yml` | xray healthcheck explainer |
| `scripts/telemt-entrypoint.sh` | cwd-change explainer |
| `scripts/lib/telemt.sh` | tls_front_dir absolute-path note |

### Verified

`bash -n` clean on touched shell, `python3 ast.parse` clean on admin/main.py, `docker compose config` parses YAML clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)